### PR TITLE
Excel error handling

### DIFF
--- a/src/Paillave.Etl.ExcelFile/Core/ExcelFileDefinition.cs
+++ b/src/Paillave.Etl.ExcelFile/Core/ExcelFileDefinition.cs
@@ -48,6 +48,7 @@ namespace Paillave.Etl.ExcelFile.Core
         }
         public ExcelFileDefinition<T> WithDataset(string stringAddress)
         {
+            ArgumentNullException.ThrowIfNull(stringAddress);
             _dataRange = new ExcelAddressBase(stringAddress);
             return this;
         }
@@ -84,6 +85,10 @@ namespace Paillave.Etl.ExcelFile.Core
         public ExcelFileReader GetExcelReader(ExcelWorksheet excelWorksheet = null)
         {
             if ((_fieldDefinitions?.Count ?? 0) == 0) SetDefaultMapping();
+            if (_dataRange == null)
+            {
+                throw new NullReferenceException($"Dataset is null and has not been specified. Please call {nameof(ExcelFileDefinition)}.{nameof(WithDataset)}.");
+            }
             IEnumerable<string> columnNames;
             if (excelWorksheet == null) columnNames = GetDefaultColumnNames().ToList();
             else columnNames = GetColumnNames(excelWorksheet);

--- a/src/Paillave.Etl.ExcelFile/ExcelRowsValuesProvider.cs
+++ b/src/Paillave.Etl.ExcelFile/ExcelRowsValuesProvider.cs
@@ -49,7 +49,7 @@ namespace Paillave.Etl.ExcelFile
         private bool ReadRow(ExcelWorksheet excelWorksheet, ExcelFileReader reader, int lineIndex, IDictionary<string, object> row)
         {
             //TODO: better exception handling here
-            if (reader.DataRange==null)
+            if (reader.DataRange == null)
             {
                 throw new ArgumentNullException(nameof(reader.DataRange));
             }

--- a/src/Paillave.Etl.ExcelFile/ExcelRowsValuesProvider.cs
+++ b/src/Paillave.Etl.ExcelFile/ExcelRowsValuesProvider.cs
@@ -49,6 +49,10 @@ namespace Paillave.Etl.ExcelFile
         private bool ReadRow(ExcelWorksheet excelWorksheet, ExcelFileReader reader, int lineIndex, IDictionary<string, object> row)
         {
             //TODO: better exception handling here
+            if (reader.DataRange==null)
+            {
+                throw new ArgumentNullException(nameof(reader.DataRange));
+            }
             bool isEmptyRow = true;
             switch (reader.DatasetOrientation)
             {


### PR DESCRIPTION
Enforce DataRange/Dataset when creating ExcelFileDefinitions. 
Current behavior: Throws a null reference exception because reader.DataRange is null.
Change: 
1. Check that the WithDataset address isn't null.
2. Throw a more descriptive null reference exception when calling GetExcelReader.
3. Throw a more helpful null reference exception when trying to read a row without a DataRange.
