### PR TITLE
Implement parameter setting in SQL generation for ODBC and OLE DB con…

### DIFF
--- a/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
+++ b/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.SqlServer</PackageId>
-    <Version>2.1.6-beta</Version>
+    <Version>2.1.7-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -15,7 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath=""/>
+    <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="../NugetIcon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
@@ -30,8 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="system.data.sqlclient" Version="4.8.5" allowedVersions="4.8.0"/>
-    <PackageReference Include="system.data.odbc" Version="7.0.0" allowedVersions="6.0.0"/>
+    <PackageReference Include="System.Data.OleDb" Version="7.0.0" />
+    <PackageReference Include="system.data.sqlclient" Version="4.8.5" allowedVersions="4.8.0" />
+    <PackageReference Include="system.data.odbc" Version="7.0.0" allowedVersions="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
+++ b/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.SqlServer</PackageId>
-    <Version>2.1.7-beta</Version>
+    <Version>2.1.6-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -15,7 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" />
+    <None Include="../../README.md" Pack="true" PackagePath=""/>
     <None Include="../NugetIcon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
@@ -30,9 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.OleDb" Version="7.0.0" />
-    <PackageReference Include="system.data.sqlclient" Version="4.8.5" allowedVersions="4.8.0" />
-    <PackageReference Include="system.data.odbc" Version="7.0.0" allowedVersions="6.0.0" />
+    <PackageReference Include="system.data.sqlclient" Version="4.8.5" allowedVersions="4.8.0"/>
+    <PackageReference Include="system.data.odbc" Version="7.0.0" allowedVersions="6.0.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -8,8 +8,6 @@ using System.Data.SqlClient;
 using System.Reflection;
 using System.Linq.Expressions;
 using System.Data;
-using System.Data.Odbc;
-using System.Data.OleDb;
 
 namespace Paillave.Etl.SqlServer
 {
@@ -22,33 +20,27 @@ namespace Paillave.Etl.SqlServer
         internal Expression<Func<TValue, object>> Pivot { get; private set; } = null;
         internal Expression<Func<TValue, object>> Computed { get; private set; } = null;
         internal SqlServerSaveCommandArgsBuilder(Func<TIn, TValue> getValue) => (GetValue) = (getValue);
-
         public SqlServerSaveCommandArgsBuilder<TIn, TValue> ToTable(string table)
         {
             this.Table = table;
             return this;
         }
-
         public SqlServerSaveCommandArgsBuilder<TIn, TValue> SeekOn(Expression<Func<TValue, object>> pivot)
         {
             this.Pivot = pivot;
             return this;
         }
-
         public SqlServerSaveCommandArgsBuilder<TIn, TValue> DoNotSave(Expression<Func<TValue, object>> computed)
         {
             this.Computed = computed;
             return this;
         }
-
         public SqlServerSaveCommandArgsBuilder<TIn, TValue> WithConnection(string connectionName)
         {
             this.ConnectionName = connectionName;
             return this;
         }
-
-        internal SqlServerSaveCommandArgs<TIn, TStream, TValue> GetArgs<TStream>(TStream sourceStream)
-            where TStream : IStream<TIn>
+        internal SqlServerSaveCommandArgs<TIn, TStream, TValue> GetArgs<TStream>(TStream sourceStream) where TStream : IStream<TIn>
             => new SqlServerSaveCommandArgs<TIn, TStream, TValue>
             {
                 Table = this.Table,
@@ -72,59 +64,40 @@ namespace Paillave.Etl.SqlServer
         public TStream SourceStream { get; set; }
         public Func<TIn, TValue> GetValue { get; set; }
     }
-
-    public class
-        SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeBase<TIn, TStream,
-            SqlServerSaveCommandArgs<TIn, TStream, TValue>>
+    public class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>
         where TIn : class
         where TStream : IStream<TIn>
     {
-        private static IDictionary<string, PropertyInfo> _inPropertyInfos = typeof(TIn).GetProperties()
-            .ToDictionary(i => i.Name, StringComparer.InvariantCultureIgnoreCase);
-
+        private static IDictionary<string, PropertyInfo> _inPropertyInfos = typeof(TIn).GetProperties().ToDictionary(i => i.Name, StringComparer.InvariantCultureIgnoreCase);
         public override ProcessImpact PerformanceImpact => ProcessImpact.Heavy;
         public override ProcessImpact MemoryFootPrint => ProcessImpact.Light;
-
-        public SqlServerSaveStreamNode(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : base(name,
-            args)
-        {
-        }
-
+        public SqlServerSaveStreamNode(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : base(name, args) { }
         protected override TStream CreateOutputStream(SqlServerSaveCommandArgs<TIn, TStream, TValue> args)
         {
             var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i), args.ConnectionName));
             return base.CreateMatchingStream(ret, args.SourceStream);
         }
-
         private string _sqlStatement = null;
         private List<PropertyInfo> _pivot = null;
         private List<PropertyInfo> _computed = null;
-
-        private string GetSqlStatement(IDbConnection connection)
+        private string GetSqlStatement()
         {
             if (_sqlStatement == null)
             {
                 _pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
-                _computed = base.Args.Computed == null
-                    ? new List<PropertyInfo>()
-                    : base.Args.Computed.GetPropertyInfos();
-                _sqlStatement = CreateSqlQuery(connection, base.Args.Table, typeof(TIn).GetProperties().ToList(), _pivot,
-                    _computed);
+                _computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
+                _sqlStatement = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), _pivot, _computed);
             }
-
             return _sqlStatement;
         }
-
         private void ProcessItem(TValue item, string connectionName)
         {
             var resolver = this.ExecutionContext.DependencyResolver;
-            var sqlConnection = connectionName == null
-                ? resolver.Resolve<IDbConnection>()
-                : resolver.Resolve<IDbConnection>(connectionName);
+            var sqlConnection = connectionName == null ? resolver.Resolve<IDbConnection>() : resolver.Resolve<IDbConnection>(connectionName);
             // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
             // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
             // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);
-            var sqlStatement = GetSqlStatement(sqlConnection);
+            var sqlStatement = GetSqlStatement();
             var command = sqlConnection.CreateCommand();
             command.CommandText = sqlStatement;
             command.CommandType = CommandType.Text;
@@ -139,7 +112,6 @@ namespace Paillave.Etl.SqlServer
                 command.Parameters.Add(parameter);
                 // command.Parameters.Add(new SqlParameter($"@{parameterName}", _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value));
             }
-
             using (var reader = command.ExecuteReader())
                 if (reader.Read())
                     UpdateRecord(reader, item);
@@ -155,14 +127,10 @@ namespace Paillave.Etl.SqlServer
                     ? null
                     : Convert.ChangeType(recordValue, record.GetFieldType(i));
             }
-
-            var updates = _inPropertyInfos.Join(values, i => i.Key, i => i.Key,
-                    (l, r) => new { Target = l.Value, NewValue = r.Value }, StringComparer.InvariantCultureIgnoreCase)
-                .ToList();
+            var updates = _inPropertyInfos.Join(values, i => i.Key, i => i.Key, (l, r) => new { Target = l.Value, NewValue = r.Value }, StringComparer.InvariantCultureIgnoreCase).ToList();
         }
 
-        private string CreateSqlQuery(IDbConnection connection, string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot,
-            List<PropertyInfo> computed)
+        private string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed)
         {
             var pivotsNames = pivot.Select(i => i.Name).ToList();
             var computedNames = computed.Select(i => i.Name).ToList();
@@ -170,32 +138,16 @@ namespace Paillave.Etl.SqlServer
             StringBuilder sb = new StringBuilder();
             if (pivot.Count > 0)
             {
-                var pivotCondition = string.Join(" AND ", pivot.Select(p => $"p.{p.Name} = {connection.GetParameter(p.Name)}"));
+                var pivotCondition = string.Join(" AND ", pivot.Select(p => $"p.{p.Name} = @{p.Name}"));
                 sb.AppendLine($"if(exists(select 1 from {table} as p where {pivotCondition} ))");
-                var setStatement = string.Join(", ",
-                    allPropertyNames.Except(pivotsNames).Except(computedNames).Select(i => $"{i} = {connection.GetParameter(i)}").ToList());
-                sb.AppendLine(
-                    $"update p set {setStatement} output inserted.* from {table} as p where {pivotCondition};");
+                var setStatement = string.Join(", ", allPropertyNames.Except(pivotsNames).Except(computedNames).Select(i => $"{i} = @{i}").ToList());
+                sb.AppendLine($"update p set {setStatement} output inserted.* from {table} as p where {pivotCondition};");
                 sb.AppendLine("else");
             }
-
             var propsToInsert = allPropertyNames.Except(computedNames).ToList();
             sb.AppendLine($"insert into {table} ({string.Join(", ", propsToInsert)}) output inserted.*");
-            sb.AppendLine($"values ({string.Join(", ", propsToInsert.Select(i => $"{connection.GetParameter(i)}"))});");
+            sb.AppendLine($"values ({string.Join(", ", propsToInsert.Select(i => $"@{i}"))});");
             return sb.ToString();
         }
     }
-
-    internal static class ConnectionExtensions
-    {
-        internal static string GetParameter(this IDbConnection connection, string? parameterName = null)
-            => connection switch 
-            {
-                OdbcConnection => "?",
-                OleDbConnection => "?",
-                SqlConnection => $"@{parameterName}",
-                _ => throw new ArgumentException($"Connection type {connection.GetType().Name} not supported")
-            };
-    }
-
 }


### PR DESCRIPTION
Adjust SQL query in `.SqlServerSave`: since named parameters are not supported in ODBC/OLE DB, named parameters have to be replaced with ? symbols and because parameters are positional, each parameter usage needs to be added as many times as it is being used in the query.