### PR TITLE
fix: Number Column With Fixed Size

### DIFF
--- a/src/Paillave.EntityFrameworkCoreExtension/Paillave.EntityFrameworkCoreExtension.csproj
+++ b/src/Paillave.EntityFrameworkCoreExtension/Paillave.EntityFrameworkCoreExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EntityFrameworkCoreExtension</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Autofac/Paillave.Etl.Autofac.csproj
+++ b/src/Paillave.Etl.Autofac/Paillave.Etl.Autofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Autofac</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Bloomberg/Paillave.Etl.Bloomberg.csproj
+++ b/src/Paillave.Etl.Bloomberg/Paillave.Etl.Bloomberg.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Bloomberg</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Dropbox/Paillave.Etl.Dropbox.csproj
+++ b/src/Paillave.Etl.Dropbox/Paillave.Etl.Dropbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Dropbox</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.EntityFrameworkCore/Paillave.Etl.EntityFrameworkCore.csproj
+++ b/src/Paillave.Etl.EntityFrameworkCore/Paillave.Etl.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.EntityFrameworkCore</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.ExcelFile/Paillave.Etl.ExcelFile.csproj
+++ b/src/Paillave.Etl.ExcelFile/Paillave.Etl.ExcelFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.ExcelFile</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.ExecutionToolkit/Paillave.Etl.ExecutionToolkit.csproj
+++ b/src/Paillave.Etl.ExecutionToolkit/Paillave.Etl.ExecutionToolkit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.ExecutionToolkit</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.FileSystem/Paillave.Etl.FileSystem.csproj
+++ b/src/Paillave.Etl.FileSystem/Paillave.Etl.FileSystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.FileSystem</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.FromConfigurationConnectors/Paillave.Etl.FromConfigurationConnectors.csproj
+++ b/src/Paillave.Etl.FromConfigurationConnectors/Paillave.Etl.FromConfigurationConnectors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.FromConfigurationConnectors</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Ftp/Paillave.Etl.Ftp.csproj
+++ b/src/Paillave.Etl.Ftp/Paillave.Etl.Ftp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Ftp</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.GraphApi/Paillave.Etl.GraphApi.csproj
+++ b/src/Paillave.Etl.GraphApi/Paillave.Etl.GraphApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.GraphApi</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Mail/Paillave.Etl.Mail.csproj
+++ b/src/Paillave.Etl.Mail/Paillave.Etl.Mail.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Mail</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Pdf/Paillave.Etl.Pdf.csproj
+++ b/src/Paillave.Etl.Pdf/Paillave.Etl.Pdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Pdf</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Sftp/Paillave.Etl.Sftp.csproj
+++ b/src/Paillave.Etl.Sftp/Paillave.Etl.Sftp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Sftp</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
+++ b/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.SqlServer</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.TextFile/FlatFileDefinition.cs
+++ b/src/Paillave.Etl.TextFile/FlatFileDefinition.cs
@@ -72,7 +72,10 @@ namespace Paillave.Etl.TextFile
             }
             if (vis.MappingSetters.Any(i => i.Size.HasValue))
             {
-                if (!vis.MappingSetters.All(i => i.Size.HasValue)) throw new InvalidOperationException("if a size is given, all sizes must be given");
+                if (!vis.MappingSetters.All(i => i.Size.HasValue))
+                    throw new InvalidOperationException(
+                        $"if a size is given, all sizes must be given: missing size for columns with indexes: {string.Join(", ", vis.MappingSetters.Where(i => !i.Size.HasValue).Select(i => i.ColumnIndex))}.");
+
                 this.HasFixedColumnWidth(vis.MappingSetters.OrderBy(i => i.ColumnIndex).Select(i => i.Size.Value).ToArray());
             }
             return this;

--- a/src/Paillave.Etl.TextFile/Paillave.Etl.TextFile.csproj
+++ b/src/Paillave.Etl.TextFile/Paillave.Etl.TextFile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.TextFile</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.XmlFile/Paillave.Etl.XmlFile.csproj
+++ b/src/Paillave.Etl.XmlFile/Paillave.Etl.XmlFile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.XmlFile</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl.Zip/Paillave.Etl.Zip.csproj
+++ b/src/Paillave.Etl.Zip/Paillave.Etl.Zip.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Zip</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Etl/Core/Mapping/Visitors/DummyFieldMapper.cs
+++ b/src/Paillave.Etl/Core/Mapping/Visitors/DummyFieldMapper.cs
@@ -94,6 +94,7 @@ namespace Paillave.Etl.Core.Mapping.Visitors
             this.MappingSetter.DecimalSeparator = decimalSeparator;
             this.MappingSetter.GroupSeparator = groupSeparator;
             this.MappingSetter.ColumnIndex = columnIndex;
+            this.MappingSetter.Size = size;
             return default;
         }
 
@@ -118,6 +119,7 @@ namespace Paillave.Etl.Core.Mapping.Visitors
             this.MappingSetter.DecimalSeparator = decimalSeparator;
             this.MappingSetter.GroupSeparator = null;
             this.MappingSetter.ColumnIndex = columnIndex;
+            this.MappingSetter.Size = size;
             return default;
         }
         #endregion

--- a/src/Paillave.Etl/Paillave.Etl.csproj
+++ b/src/Paillave.Etl/Paillave.Etl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.EtlNet.Core</PackageId>
-    <Version>2.1.14-beta</Version>
+    
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Paillave.Pdf/Paillave.Pdf.csproj
+++ b/src/Paillave.Pdf/Paillave.Pdf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Paillave.Pdf</PackageId>
-    <Version>2.1.14-beta</Version>
+    <Version>2.1.15-beta</Version>
     <Authors>Stéphane Royer</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Fix the situations were this `FlatFileDefinition` would throw an `InvalidOperationException(if a size is given, all sizes must be given)`.
Solve it and add to the exception the indexes of the columns without a specified size.
```c#
FlatFileDefinition.Create(i => new {
    first = i.ToNumberColumn<double>(0, 19, "."), // Size not taken into account
    second = i.ToColumn(1, 5),
});
```
 Targeting develop branch and increase minor version number to 2.1.15.