### PR TITLE
Handle binary values in `SqlServerSave`

### DIFF
--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -111,6 +111,8 @@ namespace Paillave.Etl.SqlServer
                 var parameter = command.CreateParameter();
                 parameter.ParameterName = $"@{parameterName}";
                 parameter.Value = _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value;
+                if (_inPropertyInfos[parameterName].PropertyType == typeof(byte[]))
+                    parameter.DbType = DbType.Binary;
                 command.Parameters.Add(parameter);
                 // command.Parameters.Add(new SqlParameter($"@{parameterName}", _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value));
             }


### PR DESCRIPTION
This probably needs to be considered in `AdjustCommandForOdbcOrOleDb()` as well, but I can’t test that. Cheers