### PR TITLE
Use TryAddWithoutValidation to avoid exception

### DIFF
--- a/src/Paillave.Etl.Http/HttpConnectionInfoEx.cs
+++ b/src/Paillave.Etl.Http/HttpConnectionInfoEx.cs
@@ -13,11 +13,19 @@ public static class IHttpConnectionInfoEx
     {
         HttpClient client = new HttpClient();
         client = ManageHeaders(client, httpConnectionInfo.HttpHeaders);
+        ApplyHeaders(client, adapterParameters.AdditionalHeaders);
         client = ManageAuthentication(client, httpConnectionInfo, adapterParameters);
         return client;
     }
 
     private static HttpClient ManageHeaders(HttpClient client, Dictionary<string, string>? headers)
+    {
+        ApplyHeaders(client, headers);
+
+        return client;
+    }
+
+    private static void ApplyHeaders(HttpClient client, Dictionary<string, string>? headers)
     {
         if (headers != null)
         {
@@ -31,8 +39,6 @@ public static class IHttpConnectionInfoEx
                 client.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
             }
         }
-
-        return client;
     }
 
     private static HttpClient ManageAuthentication(

--- a/src/Paillave.Etl.Http/HttpConnectionInfoEx.cs
+++ b/src/Paillave.Etl.Http/HttpConnectionInfoEx.cs
@@ -28,7 +28,7 @@ public static class IHttpConnectionInfoEx
                         $"Header '{header.Key}' already exists in the request."
                     );
 
-                client.DefaultRequestHeaders.Add(header.Key, header.Value);
+                client.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
             }
         }
 

--- a/src/SharedSettings.props
+++ b/src/SharedSettings.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>2.3.13-beta.0</Version>
+    <Version>2.3.14-beta.0</Version>
     <PackageIcon>NugetIcon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Authors>Stéphane Royer</Authors>


### PR DESCRIPTION
Use TryAddWithoutValidation for adding headers in HttpClient to avoid exceptions for invalid headers