### PR TITLE
Add integration tests and Graph API OneDrive file handling

### DIFF
--- a/src/Paillave.EntityFrameworkCoreExtension/Paillave.EntityFrameworkCoreExtension.csproj
+++ b/src/Paillave.EntityFrameworkCoreExtension/Paillave.EntityFrameworkCoreExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EntityFrameworkCoreExtension</PackageId>
     <PackageTags>ETL .net core EF reactive</PackageTags>
     <Product>Entity Framework extensions</Product>

--- a/src/Paillave.Etl.AzureStorageAccount/Paillave.Etl.AzureStorageAccount.csproj
+++ b/src/Paillave.Etl.AzureStorageAccount/Paillave.Etl.AzureStorageAccount.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Paillave.EtlNet.AzureStorageAccount</PackageId>

--- a/src/Paillave.Etl.Bloomberg/Paillave.Etl.Bloomberg.csproj
+++ b/src/Paillave.Etl.Bloomberg/Paillave.Etl.Bloomberg.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Bloomberg</PackageId>
     <PackageTags>ETL .net core SSIS reactive text file bloomberg</PackageTags>
     <Product>ETL.net bloomberg files extensions</Product>

--- a/src/Paillave.Etl.Dropbox/Paillave.Etl.Dropbox.csproj
+++ b/src/Paillave.Etl.Dropbox/Paillave.Etl.Dropbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Dropbox</PackageId>
     <PackageTags>ETL .net core SSIS reactive Dropbox</PackageTags>
     <Product>ETL.net Dropbox extensions</Product>

--- a/src/Paillave.Etl.EntityFrameworkCore/Paillave.Etl.EntityFrameworkCore.csproj
+++ b/src/Paillave.Etl.EntityFrameworkCore/Paillave.Etl.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.EntityFrameworkCore</PackageId>
     <PackageTags>ETL .net core SSIS reactive Entity Framework core</PackageTags>
     <Product>ETL.net EntityFrameworkCore extensions</Product>

--- a/src/Paillave.Etl.ExcelFile/Paillave.Etl.ExcelFile.csproj
+++ b/src/Paillave.Etl.ExcelFile/Paillave.Etl.ExcelFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.ExcelFile</PackageId>
     <PackageTags>ETL .net core SSIS reactive Excel file</PackageTags>
     <Product>ETL.net Excel files extensions</Product>

--- a/src/Paillave.Etl.ExecutionToolkit/Paillave.Etl.ExecutionToolkit.csproj
+++ b/src/Paillave.Etl.ExecutionToolkit/Paillave.Etl.ExecutionToolkit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.ExecutionToolkit</PackageId>
     <PackageTags>ETL .net core SSIS reactive Entity Framework core</PackageTags>
     <Product>ETL.net Execution plan extensions</Product>

--- a/src/Paillave.Etl.FileSystem/Paillave.Etl.FileSystem.csproj
+++ b/src/Paillave.Etl.FileSystem/Paillave.Etl.FileSystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.FileSystem</PackageId>
     <PackageTags>ETL .net core SSIS reactive text file csv</PackageTags>
     <Product>ETL.net file system extensions</Product>

--- a/src/Paillave.Etl.FromConfigurationConnectors/Paillave.Etl.FromConfigurationConnectors.csproj
+++ b/src/Paillave.Etl.FromConfigurationConnectors/Paillave.Etl.FromConfigurationConnectors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.FromConfigurationConnectors</PackageId>
     <PackageTags>ETL .net core SSIS reactive text file csv</PackageTags>
     <Product>ETL.net json configuration connectors</Product>

--- a/src/Paillave.Etl.Ftp/Paillave.Etl.Ftp.csproj
+++ b/src/Paillave.Etl.Ftp/Paillave.Etl.Ftp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Ftp</PackageId>
     <PackageTags>ETL .net core SSIS reactive FTP</PackageTags>
     <Product>ETL.net FTP extensions</Product>

--- a/src/Paillave.Etl.GraphApi.Tests/GraphApiOneDriveIntegrationTests.cs
+++ b/src/Paillave.Etl.GraphApi.Tests/GraphApiOneDriveIntegrationTests.cs
@@ -1,0 +1,501 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Paillave.Etl.Core;
+using Xunit;
+
+namespace Paillave.Etl.GraphApi.Tests;
+
+/// <summary>
+/// Integration tests for reading and writing files on OneDrive/SharePoint via Graph API.
+///
+/// Before running: fill in the Azure AD app registration values and target drive info below.
+/// The app registration must have the following Application permissions on Microsoft Graph:
+///   - Files.ReadWrite.All  (to list, read and upload files)
+///   - Sites.ReadWrite.All  (if you target a SharePoint site)
+///   - Group.Read.All       (if you target a group/team drive by display name)
+/// </summary>
+public class GraphApiOneDriveIntegrationTests
+{
+    // =====================================================================
+    // Azure AD app registration — fill these in
+    // =====================================================================
+    private const string TenantId     = "00000000-0000-0000-0000-000000000000";
+    private const string ClientId     = "00000000-0000-0000-0000-000000000000";
+    private const string ClientSecret = "00000000-0000-0000-0000-000000000000";
+
+    // Object-ID (GUID) or UPN of the Azure AD user whose OneDrive is used
+    // when DriveId/SiteUrl/GroupId are all null. Leave null if targeting a site/group.
+    private const string? UserId = null;
+
+    // =====================================================================
+    // Target drive — set ONE of the options below (DriveId takes priority)
+    // =====================================================================
+
+    // Option A — direct drive ID (shown in Graph Explorer, fastest)
+    private const string? DriveId = null; // e.g. "b!abc123..."
+
+    // Option B — SharePoint site URL  (leave DriveId null)
+    private const string? SiteUrl = null; // e.g. "https://contoso.sharepoint.com/sites/myteam"
+
+    // Option C — Microsoft 365 group display name or email (leave DriveId + SiteUrl null)
+    private const string? GroupDisplayNameOrEmail = null; // e.g. "My Team"
+
+    // Option D — SharePoint/OneDrive sharing URL (takes priority over all other drive sources)
+    private const string? SharingUrl = "https://"; // e.g. "https://fundprocess.sharepoint.com/:f:/g/Abc123..."
+
+    // =====================================================================
+    // Test folder — must exist on the target drive
+    // =====================================================================
+    private const string? TestFolder   = null; // "ETL_Tests";   // create this folder on OneDrive first
+    private const string ExistingFile = "Azuredatabases.csv";  // a file that already exists in TestFolder
+
+    // =====================================================================
+
+    private static GraphApiAdapterConnectionParameters ConnectionParams => new()
+    {
+        TenantId     = TenantId,
+        ClientId     = ClientId,
+        ClientSecret = ClientSecret,
+        UserId       = UserId,
+        MaxAttempts  = 1,
+    };
+
+    private static GraphApiOneDriveAdapterProviderParameters ProviderParams(
+        string? folder = TestFolder,
+        string? pattern = null,
+        bool recursive = false) => new()
+    {
+        DriveId                 = DriveId,
+        SiteUrl                 = SiteUrl,
+        GroupDisplayNameOrEmail = GroupDisplayNameOrEmail,
+        SharingUrl              = SharingUrl,
+        FolderPath              = folder,
+        FileNamePattern         = pattern,
+        Recursive               = recursive,
+    };
+
+    private static GraphApiOneDriveAdapterProcessorParameters ProcessorParams(
+        string? folder = TestFolder) => new()
+    {
+        DriveId                 = DriveId,
+        SiteUrl                 = SiteUrl,
+        GroupDisplayNameOrEmail = GroupDisplayNameOrEmail,
+        SharingUrl              = SharingUrl,
+        FolderPath              = folder,
+    };
+
+    // ------------------------------------------------------------------
+    // Helper: a simple in-memory IFileValue so we can upload arbitrary content
+    // ------------------------------------------------------------------
+    private sealed class InMemoryFileValue : FileValueBase
+    {
+        private readonly byte[] _bytes;
+        public override string Name { get; }
+
+        public InMemoryFileValue(string name, string content)
+        {
+            Name   = name;
+            _bytes = Encoding.UTF8.GetBytes(content);
+        }
+
+        protected override void DeleteFile() { }
+        public override Stream GetContent() => new MemoryStream(_bytes, writable: false);
+        public override StreamWithResource OpenContent()
+            => new StreamWithResource(new MemoryStream(_bytes, writable: false));
+    }
+
+    // ==================================================================
+    // Tests
+    // ==================================================================
+
+    /// <summary>Lists all files in <see cref="TestFolder"/> and asserts there is at least one.</summary>
+    [Fact]
+    public void ListFiles_InTestFolder_ReturnsAtLeastOneFile()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams());
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.NotEmpty(files);
+    }
+
+    /// <summary>Filters by glob pattern and asserts only matching files are returned.</summary>
+    [Fact]
+    public void ListFiles_WithGlobPattern_ReturnsOnlyMatchingFiles()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams(pattern: "*.csv"));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.All(files, f => Assert.EndsWith(".csv", f.Name));
+    }
+
+    /// <summary>Reads the content of <see cref="ExistingFile"/> and asserts the stream is non-empty.</summary>
+    [Fact]
+    public void ReadFileContent_ExistingFile_ReturnsNonEmptyStream()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams(pattern: ExistingFile));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.NotEmpty(files);
+
+        using var stream = files.First().GetContent();
+        Assert.True(stream.Length > 0);
+    }
+
+    /// <summary>Uploads a small CSV file to OneDrive.</summary>
+    [Fact]
+    public void WriteFile_SmallCsv_UploadsWithoutError()
+    {
+        const string content = "Name,Age\nAlice,30\nBob,25\n";
+        var fileToUpload = new InMemoryFileValue("integration-test.csv", content);
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "processor", "Processor", "conn",
+            ConnectionParams, ProcessorParams());
+
+        var pushed = new List<IFileValue>();
+        processor.Process(fileToUpload, pushed.Add, CancellationToken.None);
+
+        // The processor pushes the input file back unchanged after uploading it.
+        Assert.Single(pushed);
+        Assert.Equal("integration-test.csv", pushed[0].Name);
+    }
+
+    /// <summary>
+    /// Uploads a file then immediately reads it back and verifies the content matches.
+    /// Requires write + read permissions.
+    /// </summary>
+    [Fact]
+    public void WriteFile_ThenReadBack_ContentIsIdentical()
+    {
+        const string content  = "Symbol,Quantity,Price\nAAPL,100,150.25\nMSFT,50,310.50\n";
+        const string fileName = "roundtrip-test.csv";
+
+        // Upload
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "writer", "Writer", "conn",
+            ConnectionParams, ProcessorParams());
+        processor.Process(new InMemoryFileValue(fileName, content), _ => { }, CancellationToken.None);
+
+        // Read back
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(pattern: fileName));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.Single(files);
+
+        using var stream = files[0].GetContent();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        Assert.Equal(content, reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Uploads a file larger than the 4 MB threshold so the chunked upload path
+    /// (LargeFileUploadTask with 320 KB slices) is exercised.
+    /// </summary>
+    [Fact]
+    public void WriteFile_LargeFile_UploadsViaChunkedSession()
+    {
+        // Build a ~5 MB CSV — well above the 4 MB limit that triggers chunked upload.
+        const int rowCount = 55_000;
+        var sb = new StringBuilder();
+        sb.AppendLine("Id,Name,Value");
+        for (int i = 0; i < rowCount; i++)
+            sb.AppendLine($"{i},Row{i},{i * 1.23:F4}");
+        var content  = sb.ToString();
+        var fileName = "large-file-test.csv";
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "writer", "Writer", "conn",
+            ConnectionParams, ProcessorParams());
+
+        var pushed = new List<IFileValue>();
+        processor.Process(new InMemoryFileValue(fileName, content), pushed.Add, CancellationToken.None);
+
+        Assert.Single(pushed);
+    }
+
+    /// <summary>
+    /// Verifies that listing with <c>Recursive = true</c> also returns files
+    /// in sub-folders of <see cref="TestFolder"/>.
+    /// Requires at least one sub-folder with a file in it on the drive.
+    /// </summary>
+    [Fact]
+    public void ListFiles_RecursiveMode_IncludesSubFolderFiles()
+    {
+        var nonRecursive = new List<IFileValue>();
+        new GraphApiOneDriveFileValueProvider("p1", "P1", "conn",
+            ConnectionParams, ProviderParams(recursive: false))
+            .Provide(null, (fv, _) => nonRecursive.Add(fv), CancellationToken.None);
+
+        var recursive = new List<IFileValue>();
+        new GraphApiOneDriveFileValueProvider("p2", "P2", "conn",
+            ConnectionParams, ProviderParams(recursive: true))
+            .Provide(null, (fv, _) => recursive.Add(fv), CancellationToken.None);
+
+        // Recursive listing must return at least as many files as the flat one.
+        Assert.True(recursive.Count >= nonRecursive.Count);
+    }
+
+    /// <summary>
+    /// Smoke-tests the <see cref="IFileValueProvider.Test"/> method — verifies
+    /// that the drive can be resolved with the supplied credentials.
+    /// </summary>
+    [Fact]
+    public void Provider_Test_DoesNotThrow()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams());
+
+        var ex = Record.Exception(provider.Test);
+        Assert.Null(ex);
+    }
+
+    /// <summary>
+    /// Smoke-tests the <see cref="IFileValueProcessor.Test"/> method — verifies
+    /// that the drive can be resolved with the supplied credentials.
+    /// </summary>
+    [Fact]
+    public void Processor_Test_DoesNotThrow()
+    {
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "processor", "Processor", "conn",
+            ConnectionParams, ProcessorParams());
+
+        var ex = Record.Exception(processor.Test);
+        Assert.Null(ex);
+    }
+
+    /// <summary>
+    /// Uploads the same file twice and verifies that only one copy exists afterwards
+    /// (conflict behaviour = replace).
+    /// </summary>
+    [Fact]
+    public void WriteFile_Overwrite_ReplacesExistingFile()
+    {
+        const string fileName  = "overwrite-test.csv";
+        const string original  = "col1,col2\noriginal,data\n";
+        const string updated   = "col1,col2\nupdated,data\n";
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "processor", "Processor", "conn",
+            ConnectionParams, ProcessorParams());
+
+        processor.Process(new InMemoryFileValue(fileName, original), _ => { }, CancellationToken.None);
+        processor.Process(new InMemoryFileValue(fileName, updated),  _ => { }, CancellationToken.None);
+
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(pattern: fileName));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        // Exactly one file with the updated content.
+        Assert.Single(files);
+        using var stream = files[0].GetContent();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        Assert.Equal(updated, reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Uploads a file with UTF-8 content (accented characters, CJK, emoji)
+    /// and reads it back to confirm encoding is preserved end-to-end.
+    /// </summary>
+    [Fact]
+    public void WriteFile_Utf8Content_RoundTripPreservesEncoding()
+    {
+        const string content  = "Prénom,Nom,Commentaire\nÉlodie,Müller,日本語テスト 😀\nLuís,González,Ça va?\n";
+        const string fileName = "utf8-test.csv";
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "writer", "Writer", "conn",
+            ConnectionParams, ProcessorParams());
+        processor.Process(new InMemoryFileValue(fileName, content), _ => { }, CancellationToken.None);
+
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(pattern: fileName));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.Single(files);
+        using var stream = files[0].GetContent();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        Assert.Equal(content, reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Uploads several files in a loop and verifies all of them appear in the listing.
+    /// </summary>
+    [Fact]
+    public void WriteMultipleFiles_AllAppearInListing()
+    {
+        const int fileCount = 5;
+        var fileNames = Enumerable.Range(1, fileCount)
+            .Select(i => $"batch-test-{i:D2}.csv")
+            .ToList();
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "processor", "Processor", "conn",
+            ConnectionParams, ProcessorParams());
+
+        foreach (var name in fileNames)
+            processor.Process(
+                new InMemoryFileValue(name, $"id,value\n{name},42\n"),
+                _ => { }, CancellationToken.None);
+
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(pattern: "batch-test-*.csv"));
+
+        var found = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => found.Add(fv), CancellationToken.None);
+
+        Assert.True(found.Count >= fileCount,
+            $"Expected at least {fileCount} files, found {found.Count}.");
+        Assert.All(fileNames, name => Assert.Contains(found, f => f.Name == name));
+    }
+
+    /// <summary>
+    /// Uploads a file to a sub-folder path and reads it back from the same sub-folder.
+    /// The sub-folder must exist on the drive before running this test.
+    /// </summary>
+    [Fact]
+    public void WriteFile_ToSubFolder_CanBeReadBackFromSubFolder()
+    {
+        const string subFolder = "ETL_Tests/SubFolder";
+        const string fileName  = "subfolder-test.csv";
+        const string content   = "key,value\nfoo,bar\n";
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "writer", "Writer", "conn",
+            ConnectionParams, ProcessorParams(folder: subFolder));
+        processor.Process(new InMemoryFileValue(fileName, content), _ => { }, CancellationToken.None);
+
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(folder: subFolder, pattern: fileName));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.Single(files);
+        using var stream = files[0].GetContent();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        Assert.Equal(content, reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Verifies that a glob pattern that matches nothing returns an empty list
+    /// rather than throwing.
+    /// </summary>
+    [Fact]
+    public void ListFiles_PatternMatchesNothing_ReturnsEmptyList()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams(pattern: "this-file-definitely-does-not-exist-*.xyz"));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.Empty(files);
+    }
+
+    /// <summary>
+    /// Reads the content of <see cref="ExistingFile"/> twice concurrently and verifies
+    /// both streams are non-empty and identical — checks that the <see cref="IFileValue"/>
+    /// returned by the provider can be read more than once without corruption.
+    /// </summary>
+    [Fact]
+    public void ReadFileContent_TwiceConcurrently_BothStreamsAreValid()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams(pattern: ExistingFile));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+        Assert.NotEmpty(files);
+
+        var fileValue = files.First();
+
+        string read1, read2;
+        using (var s1 = fileValue.GetContent())
+        using (var r1 = new StreamReader(s1, Encoding.UTF8))
+            read1 = r1.ReadToEnd();
+
+        using (var s2 = fileValue.GetContent())
+        using (var r2 = new StreamReader(s2, Encoding.UTF8))
+            read2 = r2.ReadToEnd();
+
+        Assert.True(read1.Length > 0);
+        Assert.Equal(read1, read2);
+    }
+
+    /// <summary>
+    /// Uploads a JSON file (not CSV) and reads it back — verifies the connector
+    /// is content-agnostic and works for any file type.
+    /// </summary>
+    [Fact]
+    public void WriteAndRead_JsonFile_ContentIsPreserved()
+    {
+        const string fileName = "test-data.json";
+        const string content  = "{\"name\":\"test\",\"values\":[1,2,3],\"active\":true}\n";
+
+        var processor = new GraphApiOneDriveFileValueProcessor(
+            "writer", "Writer", "conn",
+            ConnectionParams, ProcessorParams());
+        processor.Process(new InMemoryFileValue(fileName, content), _ => { }, CancellationToken.None);
+
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "reader", "Reader", "conn",
+            ConnectionParams, ProviderParams(pattern: fileName));
+
+        var files = new List<IFileValue>();
+        provider.Provide(null, (fv, _) => files.Add(fv), CancellationToken.None);
+
+        Assert.Single(files);
+        using var stream = files[0].GetContent();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        Assert.Equal(content, reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Verifies that listing returns the correct file names (not IDs or encoded paths)
+    /// by checking the <see cref="ExistingFile"/> name is present in the listing.
+    /// </summary>
+    [Fact]
+    public void ListFiles_FileNamesAreHumanReadable()
+    {
+        var provider = new GraphApiOneDriveFileValueProvider(
+            "provider", "Provider", "conn",
+            ConnectionParams, ProviderParams());
+
+        var names = new List<string>();
+        provider.Provide(null, (fv, _) => names.Add(fv.Name), CancellationToken.None);
+
+        Assert.Contains(ExistingFile, names);
+        Assert.All(names, n => Assert.False(string.IsNullOrWhiteSpace(n)));
+    }
+}

--- a/src/Paillave.Etl.GraphApi.Tests/Paillave.Etl.GraphApi.Tests.csproj
+++ b/src/Paillave.Etl.GraphApi.Tests/Paillave.Etl.GraphApi.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paillave.Etl.GraphApi\Paillave.Etl.GraphApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValue.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValue.cs
@@ -1,0 +1,38 @@
+using Paillave.Etl.Core;
+using System;
+using System.IO;
+
+namespace Paillave.Etl.GraphApi;
+
+public class GraphApiOneDriveFileValue : FileValueBase
+{
+    public override string Name { get; }
+    public string DriveId { get; }
+    public string DriveItemId { get; }
+    public string FolderPath { get; }
+    private readonly IGraphApiConnectionInfo _connectionInfo;
+
+    internal GraphApiOneDriveFileValue(IGraphApiConnectionInfo connectionInfo, string driveId, string driveItemId, string name, string folderPath)
+        => (Name, DriveId, DriveItemId, FolderPath, _connectionInfo) = (name, driveId, driveItemId, folderPath, connectionInfo);
+
+    protected override void DeleteFile() => ActionRunner.TryExecute(_connectionInfo.MaxAttempts, DeleteFileSingleTime);
+    private void DeleteFileSingleTime()
+    {
+        using var graphClient = _connectionInfo.CreateGraphApiClient();
+        graphClient.Drives[DriveId].Items[DriveItemId].DeleteAsync().GetAwaiter().GetResult();
+    }
+
+    public override Stream GetContent() => ActionRunner.TryExecute(_connectionInfo.MaxAttempts, GetContentSingleTime);
+    private Stream GetContentSingleTime()
+    {
+        using var graphClient = _connectionInfo.CreateGraphApiClient();
+        var stream = graphClient.Drives[DriveId].Items[DriveItemId].Content
+            .GetAsync().GetAwaiter().GetResult() ?? throw new Exception("Drive item content not found");
+        var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        return ms;
+    }
+
+    public override StreamWithResource OpenContent() => new(GetContent());
+}

--- a/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValueProcessor.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValueProcessor.cs
@@ -1,0 +1,132 @@
+using Microsoft.Graph;
+using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
+using Microsoft.Graph.Models;
+using Paillave.Etl.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace Paillave.Etl.GraphApi;
+
+public class GraphApiOneDriveAdapterProcessorParameters
+{
+    /// <summary>Destination folder path inside the drive (e.g. "Reports/2024"). Leave empty for root.</summary>
+    public string? FolderPath { get; set; }
+    public bool UseStreamCopy { get; set; } = true;
+
+    // Drive source — set at most one; if none is set, uses the connection UserId personal OneDrive.
+
+    /// <summary>
+    /// Full SharePoint site URL, e.g. "https://contoso.sharepoint.com/sites/myteam".
+    /// Takes precedence over SiteId.
+    /// </summary>
+    public string? SiteUrl { get; set; }
+
+    /// <summary>SharePoint site ID in Graph format (host,siteGuid,webGuid).</summary>
+    public string? SiteId { get; set; }
+
+    /// <summary>
+    /// Display name or email of the Microsoft 365 group / Teams team,
+    /// e.g. "My Team" or "myteam@contoso.com". Takes precedence over GroupId.
+    /// </summary>
+    public string? GroupDisplayNameOrEmail { get; set; }
+
+    /// <summary>GUID of the Microsoft 365 group / Teams team.</summary>
+    public string? GroupId { get; set; }
+
+    /// <summary>Direct OneDrive/SharePoint drive ID. Overrides all other drive source options.</summary>
+    public string? DriveId { get; set; }
+
+    /// <summary>
+    /// SharePoint/OneDrive sharing URL (e.g. "https://contoso.sharepoint.com/:f:/g/Abc123...").
+    /// When set, the drive and destination folder are resolved from this link; DriveId/SiteUrl/etc. are ignored.
+    /// FolderPath is treated as a sub-path inside the shared folder.
+    /// </summary>
+    public string? SharingUrl { get; set; }
+}
+
+public class GraphApiOneDriveFileValueProcessor(string code, string name, string connectionName,
+    GraphApiAdapterConnectionParameters connectionParameters,
+    GraphApiOneDriveAdapterProcessorParameters processorParameters)
+    : FileValueProcessorBase<GraphApiAdapterConnectionParameters, GraphApiOneDriveAdapterProcessorParameters>(code, name, connectionName, connectionParameters, processorParameters)
+{
+    public override ProcessImpact PerformanceImpact => ProcessImpact.Heavy;
+    public override ProcessImpact MemoryFootPrint => ProcessImpact.Average;
+
+    protected override void Process(IFileValue fileValue,
+        GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProcessorParameters processorParameters,
+        Action<IFileValue> push,
+        CancellationToken cancellationToken)
+    {
+        using var stream = fileValue.Get(processorParameters.UseStreamCopy);
+        var ms = new MemoryStream();
+        stream.CopyTo(ms);
+
+        ActionRunner.TryExecute(connectionParameters.MaxAttempts,
+            () => UploadFileSingleTime(connectionParameters, processorParameters, fileValue.Name, ms));
+
+        push(fileValue);
+    }
+
+    private static void UploadFileSingleTime(GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProcessorParameters processorParameters, string fileName, MemoryStream ms)
+    {
+        ms.Seek(0, SeekOrigin.Begin);
+        using var graphClient = connectionParameters.CreateGraphApiClient();
+
+        var folderPath = processorParameters.FolderPath?.Trim('/') ?? "";
+        var itemPath = string.IsNullOrEmpty(folderPath) ? fileName : $"{folderPath}/{fileName}";
+        var encodedPath = GraphApiOneDriveHelper.EncodeItemPath(itemPath);
+
+        string driveId, sessionUrl;
+        if (!string.IsNullOrWhiteSpace(processorParameters.SharingUrl))
+        {
+            string sharedFolderId;
+            (driveId, sharedFolderId) = GraphApiOneDriveHelper.ResolveSharingUrl(graphClient, processorParameters.SharingUrl);
+            sessionUrl = $"https://graph.microsoft.com/v1.0/drives/{driveId}/items/{sharedFolderId}:/{encodedPath}:/createUploadSession";
+        }
+        else
+        {
+            driveId = GraphApiOneDriveHelper.ResolveDriveId(graphClient, connectionParameters.UserId,
+                processorParameters.DriveId, processorParameters.SiteId, processorParameters.SiteUrl,
+                processorParameters.GroupId, processorParameters.GroupDisplayNameOrEmail);
+            sessionUrl = $"https://graph.microsoft.com/v1.0/drives/{driveId}/root:/{encodedPath}:/createUploadSession";
+        }
+
+        // Upload session works for any file size (OneDrive requires sessions for files > 4 MB)
+        var uploadSessionBody = new CreateUploadSessionPostRequestBody
+        {
+            Item = new DriveItemUploadableProperties
+            {
+                AdditionalData = new Dictionary<string, object>
+                {
+                    { "@microsoft.graph.conflictBehavior", "replace" }
+                }
+            }
+        };
+
+        var uploadSession = graphClient.Drives[driveId].Items["placeholder"].CreateUploadSession
+            .WithUrl(sessionUrl)
+            .PostAsync(uploadSessionBody)
+            .GetAwaiter().GetResult()
+            ?? throw new Exception("Failed to create OneDrive upload session");
+
+        // 320 KB chunks — must be a multiple of 320 KB per OneDrive spec
+        var uploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, ms, 320 * 1024, graphClient.RequestAdapter);
+        uploadTask.UploadAsync().GetAwaiter().GetResult();
+    }
+
+    protected override void Test(GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProcessorParameters processorParameters)
+    {
+        using var graphClient = connectionParameters.CreateGraphApiClient();
+        if (!string.IsNullOrWhiteSpace(processorParameters.SharingUrl))
+            GraphApiOneDriveHelper.ResolveSharingUrl(graphClient, processorParameters.SharingUrl);
+        else
+            GraphApiOneDriveHelper.ResolveDriveId(graphClient, connectionParameters.UserId,
+                processorParameters.DriveId, processorParameters.SiteId, processorParameters.SiteUrl,
+                processorParameters.GroupId, processorParameters.GroupDisplayNameOrEmail);
+    }
+}

--- a/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValueProvider.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiOneDriveFileValueProvider.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Paillave.Etl.Core;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paillave.Etl.GraphApi;
+
+public class GraphApiOneDriveAdapterProviderParameters
+{
+    /// <summary>Folder path inside the drive (e.g. "Reports/2024"). Leave empty for root.</summary>
+    public string? FolderPath { get; set; }
+    public string? FileNamePattern { get; set; }
+    public bool Recursive { get; set; }
+
+    // Drive source — set at most one; if none is set, uses the connection UserId personal OneDrive.
+
+    /// <summary>
+    /// Full SharePoint site URL, e.g. "https://contoso.sharepoint.com/sites/myteam".
+    /// Takes precedence over SiteId.
+    /// </summary>
+    public string? SiteUrl { get; set; }
+
+    /// <summary>SharePoint site ID in Graph format (host,siteGuid,webGuid).</summary>
+    public string? SiteId { get; set; }
+
+    /// <summary>
+    /// Display name or email of the Microsoft 365 group / Teams team,
+    /// e.g. "My Team" or "myteam@contoso.com". Takes precedence over GroupId.
+    /// </summary>
+    public string? GroupDisplayNameOrEmail { get; set; }
+
+    /// <summary>GUID of the Microsoft 365 group / Teams team.</summary>
+    public string? GroupId { get; set; }
+
+    /// <summary>Direct OneDrive/SharePoint drive ID. Overrides all other drive source options.</summary>
+    public string? DriveId { get; set; }
+
+    /// <summary>
+    /// SharePoint/OneDrive sharing URL (e.g. "https://contoso.sharepoint.com/:f:/g/Abc123...").
+    /// When set, the drive and root folder are resolved from this link; DriveId/SiteUrl/etc. are ignored.
+    /// FolderPath is treated as a sub-path inside the shared folder.
+    /// </summary>
+    public string? SharingUrl { get; set; }
+}
+
+public class GraphApiOneDriveFileValueProvider(string code, string name, string connectionName,
+    GraphApiAdapterConnectionParameters connectionParameters,
+    GraphApiOneDriveAdapterProviderParameters providerParameters)
+    : FileValueProviderBase<GraphApiAdapterConnectionParameters, GraphApiOneDriveAdapterProviderParameters>(code, name, connectionName, connectionParameters, providerParameters)
+{
+    public override ProcessImpact PerformanceImpact => ProcessImpact.Heavy;
+    public override ProcessImpact MemoryFootPrint => ProcessImpact.Average;
+
+    private class FileSpecificData
+    {
+        public required string DriveId { get; set; }
+        public required string DriveItemId { get; set; }
+        public required string FileName { get; set; }
+        public required string FolderPath { get; set; }
+    }
+
+    protected override void Provide(object input, Action<IFileValue, FileReference> pushFileValue,
+        GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProviderParameters providerParameters,
+        CancellationToken cancellationToken)
+    {
+        using InThreadJobPool jobPool = new();
+        Task task = Task.Run(() => ActionRunner.TryExecute(connectionParameters.MaxAttempts,
+            () => GetFileList(connectionParameters, providerParameters,
+                (fv, fr) => jobPool.ExecuteAsync(() => pushFileValue(fv, fr)),
+                cancellationToken)),
+            cancellationToken);
+        jobPool.Listen(task);
+    }
+
+    public override IFileValue Provide(JsonNode? fileSpecific)
+    {
+        var data = JsonSerializer.Deserialize<FileSpecificData>(fileSpecific)
+            ?? throw new Exception("Invalid file specific");
+        return new GraphApiOneDriveFileValue(connectionParameters, data.DriveId, data.DriveItemId, data.FileName, data.FolderPath);
+    }
+
+    private void GetFileList(GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProviderParameters providerParameters,
+        Action<GraphApiOneDriveFileValue, FileReference> pushFileValue,
+        CancellationToken cancellationToken)
+    {
+        using var graphClient = connectionParameters.CreateGraphApiClient();
+
+        string driveId, startFolderId;
+        var folderDisplayPath = providerParameters.FolderPath?.Trim('/') ?? "";
+
+        if (!string.IsNullOrWhiteSpace(providerParameters.SharingUrl))
+        {
+            (driveId, startFolderId) = GraphApiOneDriveHelper.ResolveSharingUrl(graphClient, providerParameters.SharingUrl);
+            if (!string.IsNullOrEmpty(folderDisplayPath))
+                startFolderId = ResolveSubItemIdByPath(graphClient, driveId, startFolderId, folderDisplayPath);
+        }
+        else
+        {
+            driveId = GraphApiOneDriveHelper.ResolveDriveId(graphClient, connectionParameters.UserId,
+                providerParameters.DriveId, providerParameters.SiteId, providerParameters.SiteUrl,
+                providerParameters.GroupId, providerParameters.GroupDisplayNameOrEmail);
+            startFolderId = "root";
+        }
+
+        var matcher = string.IsNullOrWhiteSpace(providerParameters.FileNamePattern)
+            ? null
+            : new Matcher().AddInclude(providerParameters.FileNamePattern);
+
+        EnumerateFolder(graphClient, driveId, startFolderId,
+            folderDisplayPath, matcher, providerParameters.Recursive, pushFileValue, cancellationToken);
+    }
+
+    private void EnumerateFolder(GraphServiceClient graphClient, string driveId, string folderId,
+        string folderDisplayPath, Matcher? matcher, bool recursive,
+        Action<GraphApiOneDriveFileValue, FileReference> pushFileValue,
+        CancellationToken cancellationToken)
+    {
+        if (folderId == "root" && !string.IsNullOrEmpty(folderDisplayPath))
+            folderId = ResolveItemIdByPath(graphClient, driveId, folderDisplayPath);
+
+        var subFolders = new List<(string id, string displayPath)>();
+        var page = graphClient.Drives[driveId].Items[folderId].Children
+            .GetAsync(null, cancellationToken).GetAwaiter().GetResult();
+
+        if (page == null) return;
+
+        var pageIterator = PageIterator<DriveItem, DriveItemCollectionResponse>.CreatePageIterator(
+            graphClient,
+            page,
+            (item) =>
+            {
+                if (cancellationToken.IsCancellationRequested) return false;
+
+                if (item.File != null)
+                {
+                    var fileName = item.Name ?? "";
+                    if (matcher == null || matcher.Match(fileName).HasMatches)
+                    {
+                        var fileValue = new GraphApiOneDriveFileValue(
+                            connectionParameters,
+                            driveId,
+                            item.Id ?? throw new Exception("Drive item id is null"),
+                            fileName,
+                            folderDisplayPath);
+                        var fileReference = new FileReference(fileName, this.Code,
+                            JsonSerializer.SerializeToNode(new FileSpecificData
+                            {
+                                DriveId = driveId,
+                                DriveItemId = item.Id!,
+                                FileName = fileName,
+                                FolderPath = folderDisplayPath
+                            }));
+                        pushFileValue(fileValue, fileReference);
+                    }
+                }
+                else if (item.Folder != null && recursive && item.Name != null)
+                {
+                    var subPath = string.IsNullOrEmpty(folderDisplayPath)
+                        ? item.Name
+                        : $"{folderDisplayPath}/{item.Name}";
+                    subFolders.Add((item.Id!, subPath));
+                }
+                return true;
+            });
+
+        pageIterator.IterateAsync(cancellationToken).GetAwaiter().GetResult();
+
+        foreach (var (subId, subPath) in subFolders)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+            EnumerateFolder(graphClient, driveId, subId, subPath, matcher, recursive, pushFileValue, cancellationToken);
+        }
+    }
+
+    private static string ResolveItemIdByPath(GraphServiceClient graphClient, string driveId, string path)
+    {
+        var encodedPath = GraphApiOneDriveHelper.EncodeItemPath(path);
+        var url = $"https://graph.microsoft.com/v1.0/drives/{driveId}/root:/{encodedPath}";
+        var item = graphClient.Drives[driveId].Root.WithUrl(url).GetAsync().GetAwaiter().GetResult()
+            ?? throw new Exception($"Folder not found: {path}");
+        return item.Id ?? throw new Exception($"Folder has no id: {path}");
+    }
+
+    private static string ResolveSubItemIdByPath(GraphServiceClient graphClient, string driveId, string parentItemId, string relativePath)
+    {
+        var encodedPath = GraphApiOneDriveHelper.EncodeItemPath(relativePath);
+        var url = $"https://graph.microsoft.com/v1.0/drives/{driveId}/items/{parentItemId}:/{encodedPath}";
+        var item = graphClient.Drives[driveId].Root.WithUrl(url).GetAsync().GetAwaiter().GetResult()
+            ?? throw new Exception($"Sub-folder not found: {relativePath}");
+        return item.Id ?? throw new Exception($"Sub-folder has no id: {relativePath}");
+    }
+
+    protected override void Test(GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProviderParameters providerParameters)
+    {
+        using var graphClient = connectionParameters.CreateGraphApiClient();
+        if (!string.IsNullOrWhiteSpace(providerParameters.SharingUrl))
+            GraphApiOneDriveHelper.ResolveSharingUrl(graphClient, providerParameters.SharingUrl);
+        else
+            GraphApiOneDriveHelper.ResolveDriveId(graphClient, connectionParameters.UserId,
+                providerParameters.DriveId, providerParameters.SiteId, providerParameters.SiteUrl,
+                providerParameters.GroupId, providerParameters.GroupDisplayNameOrEmail);
+    }
+}

--- a/src/Paillave.Etl.GraphApi/GraphApiOneDriveHelper.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiOneDriveHelper.cs
@@ -1,0 +1,137 @@
+using Microsoft.Graph;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Paillave.Etl.GraphApi;
+
+internal static class GraphApiOneDriveHelper
+{
+    internal static string EncodeItemPath(string path)
+    {
+        var segments = path.Split('/');
+        var encoded = new string[segments.Length];
+        for (int i = 0; i < segments.Length; i++)
+            encoded[i] = Uri.EscapeDataString(segments[i]);
+        return string.Join("/", encoded);
+    }
+
+    internal static (string DriveId, string FolderItemId) ResolveSharingUrl(
+        GraphServiceClient graphClient, string sharingUrl)
+    {
+        // Navigation URL (browser address bar): ?id=/path/to/folder&listurl=https://...
+        if (TryParseNavigationUrl(sharingUrl, out var siteUrl, out var folderPath))
+        {
+            var driveId = ResolveDriveId(graphClient, null, null, null, siteUrl, null, null);
+            if (string.IsNullOrEmpty(folderPath))
+                return (driveId, "root");
+            var encodedPath = EncodeItemPath(folderPath);
+            var folderUrl = $"https://graph.microsoft.com/v1.0/drives/{driveId}/root:/{encodedPath}";
+            var folderItem = graphClient.Drives[driveId].Root.WithUrl(folderUrl).GetAsync().GetAwaiter().GetResult()
+                ?? throw new Exception($"Folder not found: {folderPath}");
+            return (driveId, folderItem.Id ?? throw new Exception($"Folder has no ID: {folderPath}"));
+        }
+
+        // Standard Graph API sharing link: "u!" + base64url(url) without padding
+        var shareId = "u!" + Convert.ToBase64String(Encoding.UTF8.GetBytes(sharingUrl))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+        var item = graphClient.Shares[shareId].DriveItem
+            .GetAsync().GetAwaiter().GetResult()
+            ?? throw new Exception($"Could not resolve sharing URL: {sharingUrl}");
+
+        // For cross-site sharing the real identity is in RemoteItem
+        var driveId2 = item.RemoteItem?.ParentReference?.DriveId
+            ?? item.ParentReference?.DriveId
+            ?? throw new Exception($"Could not determine drive ID from sharing URL: {sharingUrl}");
+        var itemId = item.RemoteItem?.Id
+            ?? item.Id
+            ?? throw new Exception($"Could not determine item ID from sharing URL: {sharingUrl}");
+
+        return (driveId2, itemId);
+    }
+
+    private static bool TryParseNavigationUrl(string url, out string siteUrl, out string folderPath)
+    {
+        siteUrl = "";
+        folderPath = "";
+        try
+        {
+            var uri = new Uri(url);
+            var query = uri.Query.TrimStart('?')
+                .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.Split('=', 2))
+                .Where(p => p.Length == 2)
+                .ToDictionary(p => Uri.UnescapeDataString(p[0]), p => Uri.UnescapeDataString(p[1]),
+                    StringComparer.OrdinalIgnoreCase);
+
+            if (!query.TryGetValue("id", out var id) || !query.TryGetValue("listurl", out var listUrl))
+                return false;
+
+            // listurl = "https://tenant.sharepoint.com/sites/Finance/Documents"
+            // → site  = "https://tenant.sharepoint.com/sites/Finance"  (strip last segment = library)
+            var listUri = new Uri(listUrl);
+            var segments = listUri.AbsolutePath.TrimEnd('/').Split('/');
+            var sitePath = string.Join("/", segments.Take(segments.Length - 1));
+            siteUrl = $"{listUri.Scheme}://{listUri.Host}{sitePath}";
+
+            // id = "/sites/Finance/Documents/TestFromApp"
+            // library prefix = "/sites/Finance/Documents"  (= listUri.AbsolutePath without trailing slash)
+            // → drive-relative path = "TestFromApp"
+            var libraryPath = listUri.AbsolutePath.TrimEnd('/');
+            var serverRelative = id.TrimEnd('/');
+            folderPath = serverRelative.StartsWith(libraryPath + "/", StringComparison.OrdinalIgnoreCase)
+                ? serverRelative[(libraryPath.Length + 1)..]
+                : string.Compare(serverRelative, libraryPath, StringComparison.OrdinalIgnoreCase) == 0
+                    ? ""          // id points to the library itself → list from drive root
+                    : id.TrimStart('/');
+
+            return true;
+        }
+        catch { return false; }
+    }
+
+    internal static string ResolveDriveId(GraphServiceClient graphClient, string? defaultUserId,
+        string? driveId, string? siteId, string? siteUrl, string? groupId, string? groupDisplayNameOrEmail)
+    {
+        if (!string.IsNullOrWhiteSpace(driveId))
+            return driveId;
+
+        if (!string.IsNullOrWhiteSpace(siteUrl))
+        {
+            var uri = new Uri(siteUrl);
+            // Graph API accepts "hostname:/server-relative-path" as site identifier
+            var siteIdentifier = $"{uri.Host}:{uri.AbsolutePath.TrimEnd('/')}";
+            return graphClient.Sites[siteIdentifier].Drive.GetAsync().GetAwaiter().GetResult()?.Id
+                ?? throw new Exception($"Could not get drive for site URL: {siteUrl}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(siteId))
+            return graphClient.Sites[siteId].Drive.GetAsync().GetAwaiter().GetResult()?.Id
+                ?? throw new Exception($"Could not get drive for site ID: {siteId}");
+
+        if (!string.IsNullOrWhiteSpace(groupDisplayNameOrEmail))
+        {
+            var safe = groupDisplayNameOrEmail.Replace("'", "''"); // OData single-quote escape
+            var response = graphClient.Groups.GetAsync(r =>
+            {
+                r.QueryParameters.Filter = $"displayName eq '{safe}' or mail eq '{safe}'";
+                r.QueryParameters.Top = 1;
+                r.QueryParameters.Select = ["id"];
+            }).GetAwaiter().GetResult();
+            var group = response?.Value?.FirstOrDefault()
+                ?? throw new Exception($"Group/Team not found: {groupDisplayNameOrEmail}");
+            return graphClient.Groups[group.Id!].Drive.GetAsync().GetAwaiter().GetResult()?.Id
+                ?? throw new Exception($"Could not get drive for group: {groupDisplayNameOrEmail}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(groupId))
+            return graphClient.Groups[groupId].Drive.GetAsync().GetAwaiter().GetResult()?.Id
+                ?? throw new Exception($"Could not get drive for group ID: {groupId}");
+
+        if (string.IsNullOrWhiteSpace(defaultUserId))
+            throw new Exception("UserId is required when no DriveId, SiteUrl, SiteId, GroupId or GroupDisplayNameOrEmail is provided.");
+        return graphClient.Users[defaultUserId].Drive.GetAsync().GetAwaiter().GetResult()?.Id
+            ?? throw new Exception($"Could not get drive for user: {defaultUserId}");
+    }
+}

--- a/src/Paillave.Etl.GraphApi/GraphApiOneDriveProviderProcessorAdapter.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiOneDriveProviderProcessorAdapter.cs
@@ -1,0 +1,19 @@
+using Paillave.Etl.Core;
+
+namespace Paillave.Etl.GraphApi;
+
+public class GraphApiOneDriveProviderProcessorAdapter : ProviderProcessorAdapterBase<GraphApiAdapterConnectionParameters, GraphApiOneDriveAdapterProviderParameters, GraphApiOneDriveAdapterProcessorParameters>
+{
+    public override string Description => "Get and save files on OneDrive or SharePoint via GraphAPI";
+    public override string Name => "GraphApiOneDrive";
+
+    protected override IFileValueProvider CreateProvider(string code, string name, string connectionName,
+        GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProviderParameters inputParameters)
+        => new GraphApiOneDriveFileValueProvider(code, name, connectionName, connectionParameters, inputParameters);
+
+    protected override IFileValueProcessor CreateProcessor(string code, string name, string connectionName,
+        GraphApiAdapterConnectionParameters connectionParameters,
+        GraphApiOneDriveAdapterProcessorParameters outputParameters)
+        => new GraphApiOneDriveFileValueProcessor(code, name, connectionName, connectionParameters, outputParameters);
+}

--- a/src/Paillave.Etl.GraphApi/GraphApiProviderProcessorAdapter.cs
+++ b/src/Paillave.Etl.GraphApi/GraphApiProviderProcessorAdapter.cs
@@ -14,8 +14,7 @@ public class GraphApiAdapterConnectionParameters : IGraphApiConnectionInfo
     [Required]
     [Sensitive]
     public string ClientSecret { get; set; }
-    [Required]
-    public string UserId { get; set; }
+    public string? UserId { get; set; }
     public int MaxAttempts { get; set; } = 3;
     public bool SaveToSentItems { get; set; } = true;
 }

--- a/src/Paillave.Etl.GraphApi/IGraphApiConnectionInfo.cs
+++ b/src/Paillave.Etl.GraphApi/IGraphApiConnectionInfo.cs
@@ -7,7 +7,8 @@ public interface IGraphApiConnectionInfo
     string TenantId { get; set; }
     string ClientId { get; set; }
     string ClientSecret { get; set; }
-    string UserId { get; set; }
+    /// <summary>Object ID (GUID) or UPN / email address of the Azure AD user (both accepted by Graph API).</summary>
+    string? UserId { get; set; }
     int MaxAttempts { get; set; }
     bool SaveToSentItems { get; set; }
 }

--- a/src/Paillave.Etl.GraphApi/Paillave.Etl.GraphApi.csproj
+++ b/src/Paillave.Etl.GraphApi/Paillave.Etl.GraphApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.GraphApi</PackageId>
     <PackageTags>ETL .net core SSIS reactive GraphApi Mail</PackageTags>
     <Product>ETL.net Mail extensions</Product>

--- a/src/Paillave.Etl.Http/Paillave.Etl.Http.csproj
+++ b/src/Paillave.Etl.Http/Paillave.Etl.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Http</PackageId>
     <PackageTags>ETL .net core SSIS Http Responses</PackageTags>
     <Product>ETL.net Http extensions</Product>

--- a/src/Paillave.Etl.JsonFile/Paillave.Etl.JsonFile.csproj
+++ b/src/Paillave.Etl.JsonFile/Paillave.Etl.JsonFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.JsonFile</PackageId>
     <PackageTags>ETL .net core SSIS JsonFile Connectors</PackageTags>
     <Product>ETL.net JsonFile extensions</Product>

--- a/src/Paillave.Etl.Mail/Paillave.Etl.Mail.csproj
+++ b/src/Paillave.Etl.Mail/Paillave.Etl.Mail.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Mail</PackageId>
     <PackageTags>ETL .net core SSIS reactive Mail</PackageTags>
     <Product>ETL.net Mail extensions</Product>

--- a/src/Paillave.Etl.Pdf/Paillave.Etl.Pdf.csproj
+++ b/src/Paillave.Etl.Pdf/Paillave.Etl.Pdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Pdf</PackageId>
     <PackageTags>ETL .net core SSIS reactive Pdf file</PackageTags>
     <Product>ETL.net PDF files extensions</Product>

--- a/src/Paillave.Etl.Pgp/Paillave.Etl.Pgp.csproj
+++ b/src/Paillave.Etl.Pgp/Paillave.Etl.Pgp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Pgp</PackageId>
     <PackageTags>ETL .net core SSIS reactive pgp</PackageTags>
     <Product>ETL.net PGP extensions</Product>

--- a/src/Paillave.Etl.S3/Paillave.Etl.S3.csproj
+++ b/src/Paillave.Etl.S3/Paillave.Etl.S3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.S3</PackageId>
     <PackageTags>ETL .net core SSIS reactive S3</PackageTags>
     <Product>ETL.net S3 extensions</Product>

--- a/src/Paillave.Etl.Sftp/Paillave.Etl.Sftp.csproj
+++ b/src/Paillave.Etl.Sftp/Paillave.Etl.Sftp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Sftp</PackageId>
     <PackageTags>ETL .net core SSIS reactive SFTP</PackageTags>
     <Product>ETL.net SFTP extensions</Product>

--- a/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
+++ b/src/Paillave.Etl.SqlServer/Paillave.Etl.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.SqlServer</PackageId>
     <PackageTags>ETL .net core SSIS reactive SqlServer</PackageTags>
     <Product>ETL.net Sql Server extensions</Product>

--- a/src/Paillave.Etl.Tests/Paillave.Etl.Tests.csproj
+++ b/src/Paillave.Etl.Tests/Paillave.Etl.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
 

--- a/src/Paillave.Etl.TextFile/Paillave.Etl.TextFile.csproj
+++ b/src/Paillave.Etl.TextFile/Paillave.Etl.TextFile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.TextFile</PackageId>
     <PackageTags>ETL .net core SSIS reactive text file csv</PackageTags>
     <Product>ETL.net text files extensions</Product>

--- a/src/Paillave.Etl.XmlFile/Paillave.Etl.XmlFile.csproj
+++ b/src/Paillave.Etl.XmlFile/Paillave.Etl.XmlFile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.XmlFile</PackageId>
     <PackageTags>ETL .net core SSIS reactive text file xml</PackageTags>
     <Product>ETL.net XML files extensions</Product>

--- a/src/Paillave.Etl.XmlFileTests/Paillave.Etl.XmlFileTests.csproj
+++ b/src/Paillave.Etl.XmlFileTests/Paillave.Etl.XmlFileTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
 

--- a/src/Paillave.Etl.Zip/Paillave.Etl.Zip.csproj
+++ b/src/Paillave.Etl.Zip/Paillave.Etl.Zip.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Zip</PackageId>
     <PackageTags>ETL .net core SSIS reactive zip</PackageTags>
     <Product>ETL.net ZIP extensions</Product>

--- a/src/Paillave.Etl.sln
+++ b/src/Paillave.Etl.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.Pgp", "Paillav
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.JsonFile", "Paillave.Etl.JsonFile\Paillave.Etl.JsonFile.csproj", "{F151FFFE-9295-4A1C-932B-4F655DE6724C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.GraphApi.Tests", "Paillave.Etl.GraphApi.Tests\Paillave.Etl.GraphApi.Tests.csproj", "{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -405,6 +407,18 @@ Global
 		{F151FFFE-9295-4A1C-932B-4F655DE6724C}.Release|x64.Build.0 = Release|Any CPU
 		{F151FFFE-9295-4A1C-932B-4F655DE6724C}.Release|x86.ActiveCfg = Release|Any CPU
 		{F151FFFE-9295-4A1C-932B-4F655DE6724C}.Release|x86.Build.0 = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|x64.Build.0 = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Debug|x86.Build.0 = Debug|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|x64.ActiveCfg = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|x64.Build.0 = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|x86.ActiveCfg = Release|Any CPU
+		{82E4637C-A0AB-4AFB-A6BC-FEC3892CB7C9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Paillave.Etl/Paillave.Etl.csproj
+++ b/src/Paillave.Etl/Paillave.Etl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.EtlNet.Core</PackageId>
     <PackageTags>ETL .net core SSIS reactive</PackageTags>
     <Product>ETL.net Core</Product>

--- a/src/Paillave.Pdf/Paillave.Pdf.csproj
+++ b/src/Paillave.Pdf/Paillave.Pdf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\SharedSettings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>Paillave.Pdf</PackageId>
     <PackageTags>Pdf file</PackageTags>
     <Product>PDF files extensions</Product>

--- a/src/SharedSettings.props
+++ b/src/SharedSettings.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>2.4.1</Version>
+    <Version>2.5.0</Version>
     <PackageIcon>NugetIcon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Authors>Stéphane Royer</Authors>

--- a/src/Tutorials/BlogTutorial/BlogTutorial.csproj
+++ b/src/Tutorials/BlogTutorial/BlogTutorial.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Tutorials/Paillave.Etl.Samples/Paillave.Etl.Samples.csproj
+++ b/src/Tutorials/Paillave.Etl.Samples/Paillave.Etl.Samples.csproj
@@ -35,7 +35,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Tutorials/SimpleTutorial/SimpleTutorial.csproj
+++ b/src/Tutorials/SimpleTutorial/SimpleTutorial.csproj
@@ -29,7 +29,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Implemented integration tests for reading and writing files on OneDrive/SharePoint via Graph API in `GraphApiOneDriveIntegrationTests.cs`.
- Created `GraphApiOneDriveFileValue`, `GraphApiOneDriveFileValueProcessor`, and `GraphApiOneDriveFileValueProvider` classes for handling file operations.
- Added helper methods in `GraphApiOneDriveHelper` for resolving sharing URLs and drive IDs.
- Introduced `GraphApiOneDriveProviderProcessorAdapter` to facilitate provider and processor creation.
- Defined project file for the test project with necessary dependencies.