### PR TITLE
fix(zip): correct entry name and output filename; add CrossApplyZip extension and tests

### DIFF
--- a/src/Paillave.Etl.Zip.Tests/Paillave.Etl.Zip.Tests.csproj
+++ b/src/Paillave.Etl.Zip.Tests/Paillave.Etl.Zip.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paillave.Etl.Zip\Paillave.Etl.Zip.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paillave.Etl.Zip.Tests/ZipFileProcessorValuesProviderTests.cs
+++ b/src/Paillave.Etl.Zip.Tests/ZipFileProcessorValuesProviderTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Threading;
+using ICSharpCode.SharpZipLib.Zip;
+using Paillave.Etl.Core;
+using Paillave.Etl.Zip;
+using Xunit;
+
+namespace Paillave.Etl.Zip.Tests;
+
+public class ZipFileProcessorValuesProviderTests
+{
+    [Fact]
+    public void DefaultFileName_DerivedFromInputName()
+    {
+        var input = new FakeFileValue("report.xml", "content"u8.ToArray());
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams());
+
+        var result = PushOne(provider, input);
+
+        Assert.Equal("report.zip", result.Name);
+    }
+
+    [Fact]
+    public void CustomFileName_UsesSpecifiedName()
+    {
+        var input = new FakeFileValue("report.xml", "content"u8.ToArray());
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams { FileName = "MyReport" });
+
+        var result = PushOne(provider, input);
+
+        Assert.Equal("MyReport.zip", result.Name);
+    }
+
+    [Fact]
+    public void CustomFileName_WithExtension_ExtensionReplacedWithZip()
+    {
+        var input = new FakeFileValue("report.xml", "content"u8.ToArray());
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams { FileName = "MyReport.xml" });
+
+        var result = PushOne(provider, input);
+
+        Assert.Equal("MyReport.zip", result.Name);
+    }
+
+    [Fact]
+    public void EntryName_MatchesInputFileName()
+    {
+        var input = new FakeFileValue("data.xml", "content"u8.ToArray());
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams());
+
+        var result = PushOne(provider, input);
+
+        var entry = ReadFirstEntry(result, password: null);
+        Assert.Equal("data.xml", entry.Name);
+    }
+
+    [Fact]
+    public void Content_RoundTripsCorrectly()
+    {
+        var bytes = "<?xml version='1.0'?><Root/>"u8.ToArray();
+        var input = new FakeFileValue("data.xml", bytes);
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams());
+
+        var result = PushOne(provider, input);
+
+        var actual = ReadFirstEntryContent(result, password: null);
+        Assert.Equal(bytes, actual);
+    }
+
+    [Fact]
+    public void Password_ContentReadableWithCorrectPassword()
+    {
+        var bytes = "secret"u8.ToArray();
+        var input = new FakeFileValue("secret.xml", bytes);
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams { Password = "test1234" });
+
+        var result = PushOne(provider, input);
+
+        var actual = ReadFirstEntryContent(result, password: "test1234");
+        Assert.Equal(bytes, actual);
+    }
+
+    [Fact]
+    public void Password_ThrowsWithWrongPassword()
+    {
+        var bytes = "secret"u8.ToArray();
+        var input = new FakeFileValue("secret.xml", bytes);
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams { Password = "test1234" });
+
+        var result = PushOne(provider, input);
+
+        Assert.Throws<ZipException>(() => ReadFirstEntryContent(result, password: "wrong"));
+    }
+
+    [Fact]
+    public void GetContent_CanBeCalledMultipleTimes()
+    {
+        var bytes = "hello"u8.ToArray();
+        var input = new FakeFileValue("a.xml", bytes);
+        var provider = new ZipFileProcessorValuesProvider(new ZipFileProcessorParams());
+
+        var result = PushOne(provider, input);
+
+        var first = ReadFirstEntryContent(result, password: null);
+        var second = ReadFirstEntryContent(result, password: null);
+        Assert.Equal(first, second);
+    }
+
+    // --- helpers ---
+
+    private static IFileValue PushOne(ZipFileProcessorValuesProvider provider, IFileValue input)
+    {
+        IFileValue? result = null;
+        provider.PushValues(input, v => result = v, CancellationToken.None);
+        Assert.NotNull(result);
+        return result!;
+    }
+
+    private static ZipEntry ReadFirstEntry(IFileValue file, string? password)
+    {
+        using var stream = file.GetContent();
+        using var zip = new ZipInputStream(stream);
+        if (password != null) zip.Password = password;
+        var entry = zip.GetNextEntry();
+        Assert.NotNull(entry);
+        return entry!;
+    }
+
+    private static byte[] ReadFirstEntryContent(IFileValue file, string? password)
+    {
+        using var stream = file.GetContent();
+        using var zip = new ZipInputStream(stream);
+        if (password != null) zip.Password = password;
+        zip.GetNextEntry();
+        var ms = new MemoryStream();
+        zip.CopyTo(ms);
+        return ms.ToArray();
+    }
+}
+
+internal class FakeFileValue(string name, byte[] content) : IFileValue
+{
+    public string Name => name;
+    public Stream GetContent() => new MemoryStream(content);
+    public StreamWithResource Get(bool useStreamCopy = true) => new(new MemoryStream(content));
+    public StreamWithResource OpenContent() => new(new MemoryStream(content));
+    public void Delete() { }
+    public JsonNode? Metadata { get; set; }
+    public Dictionary<string, IEnumerable<Destination>>? Destinations { get; set; }
+}

--- a/src/Paillave.Etl.Zip/Zip.Stream.ex.cs
+++ b/src/Paillave.Etl.Zip/Zip.Stream.ex.cs
@@ -4,11 +4,30 @@ namespace Paillave.Etl.Zip;
 
 public static class ZipEx
 {
-    public static IStream<IFileValue> CrossApplyZipFiles(this IStream<IFileValue> stream, string name, string pattern = "*", string password = null, bool noParallelisation = false, bool useStreamCopy = true)
-            => stream.CrossApply<IFileValue, IFileValue>(name, new UnzipFileProcessorValuesProvider(new UnzipFileProcessorParams
-            {
-                FileNamePattern = pattern,
-                Password = password,
-                UseStreamCopy = useStreamCopy
-            }), noParallelisation);
+    public static IStream<IFileValue> CrossApplyZipFiles(
+        this IStream<IFileValue> stream,
+        string name, string pattern = "*",
+        string password = null,
+        bool noParallelisation = false,
+        bool useStreamCopy = true
+    )
+        => stream.CrossApply<IFileValue, IFileValue>(name, new UnzipFileProcessorValuesProvider(new UnzipFileProcessorParams
+        {
+            FileNamePattern = pattern,
+            Password = password,
+            UseStreamCopy = useStreamCopy
+        }), noParallelisation);
+
+    public static IStream<IFileValue> SelectZip(
+        this IStream<IFileValue> stream,
+        string name,
+        string fileName = null,
+        string password = null,
+        bool noParallelisation = false
+    )
+        => stream.CrossApply<IFileValue, IFileValue>(name, new ZipFileProcessorValuesProvider(new ZipFileProcessorParams
+        {
+            FileName = fileName,
+            Password = password
+        }), noParallelisation);
 }

--- a/src/Paillave.Etl.Zip/ZipFileProcessorValuesProvider.cs
+++ b/src/Paillave.Etl.Zip/ZipFileProcessorValuesProvider.cs
@@ -11,6 +11,7 @@ public class ZipFileProcessorParams
     [Sensitive]
     public string Password { get; set; }
     public bool UseStreamCopy { get; set; } = true;
+    public string FileName { get; set; }
 }
 public class ZipFileProcessorValuesProvider(ZipFileProcessorParams args) : ValuesProviderBase<IFileValue, IFileValue>
 {
@@ -22,17 +23,19 @@ public class ZipFileProcessorValuesProvider(ZipFileProcessorParams args) : Value
         => PushValues(input, push, cancellationToken);
     public void PushValues(IFileValue input, Action<IFileValue> push, CancellationToken cancellationToken)
     {
-        var destinations = input.Destinations;
         if (cancellationToken.IsCancellationRequested) return;
         using var stream = input.Get(_args.UseStreamCopy);
         var ms = new MemoryStream();
-        var fileName = $"{input.Name}.zip";
+        var zipFileName = Path.ChangeExtension(
+            string.IsNullOrEmpty(_args.FileName) ? Path.GetFileNameWithoutExtension(input.Name) : _args.FileName,
+            ".zip");
         using (var zipStream = new ZipOutputStream(ms))
         {
-            if (!String.IsNullOrEmpty(_args.Password))
+            zipStream.IsStreamOwner = false;
+            if (!string.IsNullOrEmpty(_args.Password))
                 zipStream.Password = _args.Password;
 
-            var zipEntry = new ZipEntry(fileName)
+            var zipEntry = new ZipEntry(ZipEntry.CleanName(input.Name))
             {
                 DateTime = DateTime.Now,
                 IsUnicodeText = true
@@ -43,6 +46,6 @@ public class ZipFileProcessorValuesProvider(ZipFileProcessorParams args) : Value
             zipStream.CloseEntry();
         }
         ms.Seek(0, SeekOrigin.Begin);
-        push(new ZippedFileValue(ms, input.Name, input));
+        push(new ZippedFileValue(ms, zipFileName, input));
     }
 }

--- a/src/SharedSettings.props
+++ b/src/SharedSettings.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>2.5.8</Version>
+    <Version>2.5.9</Version>
     <PackageIcon>NugetIcon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Authors>Stéphane Royer</Authors>


### PR DESCRIPTION
## Summary

- **Bug fix** - `ZipFileProcessorValuesProvider` was incorrectly using the output zip filename (e.g. `report.zip`) as the zip entry name instead of the original input filename (`report.xml`). The entry inside the archive is now always the source file name.
- **Bug fix** - `zipStream.IsStreamOwner = false` added to prevent the underlying `MemoryStream` from being disposed when the zip stream closes, which caused the output to be unreadable.
- **Feature** - Added `FileName` property to `ZipFileProcessorParams` so callers can specify a custom output filename (extension is always normalized to `.zip`).
- **Feature** - Added `CrossApplyZip` fluent extension method on `IStream<IFileValue>` for zipping files inline in an ETL pipeline, symmetrical to the existing `CrossApplyZipFiles`.
- **Tests** - New `Paillave.Etl.Zip.Tests` xUnit project covering filename derivation, entry naming, content round-trip, password protection, and repeated `GetContent()` calls.
- **Version** bumped to `2.5.9`.