### PR TITLE
Fix connection pool exhaustion in `SqlServerSave()` by disposing the connection.

### DIFF
--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -95,9 +95,9 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
     }
     private void ProcessItem(TValue item, string connectionName)
     {
-    var sqlConnection = connectionName == null 
-        ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
-        : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
+        using var sqlConnection = connectionName == null 
+                                ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
+                                : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
         // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
         // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
         // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);


### PR DESCRIPTION
Using this example from the docs, the connection pool would get exhausted after about 100 rows, because every item would new up a fresh connection and never return it to the pool:

```
var services = new ServiceCollection().AddTransient<IDbConnection>(_ =>
{
    var c = new SqlConnection("Server=...;Database=Demo;Integrated Security=true;");
    c.Open();
    return c;
}).BuildServiceProvider();
```

This could be worked around by registering a single concrete connection, but I guess this is the more proper way.