### PR TITLE
Docs: Update outdated example in Readme to actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Extend it takes 5mn... literally.
 
 ## Examples
 
-### Unzip it, read it, save it, report it
+### Extract it, parse it, upload it
 
-Read all zip files from a folder, unzip csv files that are inside, parse them, exclude duplicates, upsert them into database, and report new or pre existing id corresponding to the email.
+Read all Zip files from a folder, unzip Csv files that are inside, parse them, exclude duplicates, and upsert them into database.
 
 ```
 dotnet new console -o SimpleTutorial
@@ -66,73 +66,71 @@ dotnet add package Paillave.EtlNet.SqlServer
 ```
 
 ```csharp
-using System;
-using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
 using Paillave.Etl.Core;
 using Paillave.Etl.FileSystem;
-using Paillave.Etl.Zip;
-using Paillave.Etl.TextFile;
 using Paillave.Etl.SqlServer;
-using Microsoft.Data.SqlClient;
-using System.Linq;
+using Paillave.Etl.TextFile;
+using Paillave.Etl.Zip;
+using System.Data;
 
-namespace SimpleTutorial
+//Register services
+var serviceCollection = new ServiceCollection();
+serviceCollection.AddTransient<IDbConnection>(_ =>
 {
-    class Program
-    {
-        static async Task Main(string[] args)
-        {
-            var processRunner = StreamProcessRunner.Create<string>(DefineProcess);
-            processRunner.DebugNodeStream += (sender, e) => { /* place a conditional breakpoint here for debug */ };
-            using (var cnx = new SqlConnection(args[1]))
+    var conn = new SqlConnection(@"Data Source=MyServer;Initial Catalog=MyDatabase;Integrated Security=True;");
+    conn.Open();
+    return conn;
+});
+var services = serviceCollection.BuildServiceProvider();
+
+
+//Configure an ETL execution (defined below)
+var processRunner = StreamProcessRunner.Create<string>(DefineProcess);
+var executionOptions = new ExecutionOptions<string>
+{
+    Services = services,
+};
+var result = await processRunner.ExecuteAsync(@"C:\Path\To\My\Zip-Files", executionOptions);
+
+Console.WriteLine(result.Failed
+    ? $"{result.ErrorTraceEvent.NodeName} ({result.ErrorTraceEvent.NodeTypeName}): {result.ErrorTraceEvent.Content.Message}"
+    : "Success!");
+
+
+//Define the ETL process, in this case starting from a single path string
+static void DefineProcess(ISingleStream<string> contextStream)
+{
+    contextStream
+        .CrossApplyFolderFiles("List all Zip files", "*.zip", recursive: true)
+        .CrossApplyZipFiles("Extract Csv files from Zips", "*.csv")
+        .CrossApplyTextFile("Parse Csv files", FlatFileDefinition.Create(i => new Person
             {
-                cnx.Open();
-                var executionOptions = new ExecutionOptions<string>
-                {
-                    Resolver = new SimpleDependencyResolver().Register(cnx),
-                };
-                var res = await processRunner.ExecuteAsync(args[0], executionOptions);
-                Console.Write(res.Failed ? "Failed" : "Succeeded");
-                if (res.Failed)
-                    Console.Write($"{res.ErrorTraceEvent.NodeName}({res.ErrorTraceEvent.NodeTypeName}):{res.ErrorTraceEvent.Content.Message}");
-            }
-        }
-        private static void DefineProcess(ISingleStream<string> contextStream)
-        {
-            contextStream
-                .CrossApplyFolderFiles("list all required files", "*.zip", true)
-                .CrossApplyZipFiles("extract files from zip", "*.csv")
-                .CrossApplyTextFile("parse file", FlatFileDefinition.Create(i => new Person
-                {
-                    Email = i.ToColumn("email"),
-                    FirstName = i.ToColumn("first name"),
-                    LastName = i.ToColumn("last name"),
-                    DateOfBirth = i.ToDateColumn("date of birth", "yyyy-MM-dd"),
-                    Reputation = i.ToNumberColumn<int?>("reputation", ".")
-                }).IsColumnSeparated(','))
-                .Distinct("exclude duplicates based on the Email", i => i.Email)
-                .SqlServerSave("upsert using Email as key and ignore the Id", o => o
-                    .ToTable("dbo.Person")
-                    .SeekOn(p => p.Email)
-                    .DoNotSave(p => p.Id))
-                .Select("define row to report", i => new { i.Email, i.Id })
-                .ToTextFileValue("write summary to file", "report.csv", FlatFileDefinition.Create(i => new
-                {
-                    Email = i.ToColumn("Email"),
-                    Id = i.ToNumberColumn<int>("new or existing Id", ".")
-                }).IsColumnSeparated(','))
-                .WriteToFile("save log file", i => i.Name);
-        }
-        private class Person
-        {
-            public int Id { get; set; }
-            public string Email { get; set; }
-            public string FirstName { get; set; }
-            public string LastName { get; set; }
-            public DateTime DateOfBirth { get; set; }
-            public int? Reputation { get; set; }
-        }
-    }
+                FirstName = i.ToColumn("first name"),
+                LastName = i.ToColumn("last name"),
+                DateOfBirth = i.ToDateColumn("date of birth", "yyyy-MM-dd"),
+                Email = i.ToColumn("email"),
+                Reputation = i.ToNumberColumn<int?>("reputation", ".")
+            })
+            .IsColumnSeparated(',')
+        )
+        .Distinct("Exclude duplicates based on the Email", p => p.Email)
+        .SqlServerSave("Upsert using Email as key and ignore the Id", o => o
+            .ToTable("dbo.Person")
+            .SeekOn(p => p.Email)
+            .DoNotSave(p => p.Id));
+}
+
+
+class Person
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public DateTime DateOfBirth { get; set; }
+    public string Email { get; set; }
+    public int? Reputation { get; set; }
 }
 ```
 


### PR DESCRIPTION
Updated the very first code example in the readme to work with the current release, namely to use `ServiceProvider`.

Other changes:
* Threw out boilerplate in favor of top-level statements, but it’s still a complete program you can just copy and run unmodified (provided you had the files and the database).
* Removed the text file export at the end, because getting Ids back from the database does not currently work (at least not with the SqlServer library)
* Removed debug processing for simplicity, as it didn’t do anything anyway
* Added explanatory comments
* Small stylistic changes (capitalized node names etc.)

Thanks!