### PR TITLE
Refactor `SqlServerSave()`. Bugfixes, features, performance, documentation and maintainability improvements

### DIFF
--- a/src/Paillave.Etl.SqlServer.Tests/DatabaseFixture.cs
+++ b/src/Paillave.Etl.SqlServer.Tests/DatabaseFixture.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Data.SqlClient;
+using System;
+using System.Data.Odbc;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Paillave.Etl.SqlServer.Tests;
+
+
+[CollectionDefinition("MSSQLLocalDB")]
+public sealed class DatabaseCollection : ICollectionFixture<DatabaseFixture>{ }
+
+
+public sealed class DatabaseFixture : IAsyncLifetime
+{
+    public string DatabaseName { get; } = $"Test_{Guid.CreateVersion7():N}";
+    private const string ConnectionStringMaster = @"Server=(localdb)\MSSQLLocalDB;Database=master;Integrated Security=True;TrustServerCertificate=True;";
+
+    public async Task InitializeAsync()
+    {
+        await CreateDatabaseAsync();
+        await CreateSchemaAsync();
+        await ResetSeedDataAsync();
+    }
+
+
+    public SqlConnection CreateConnection() => new SqlConnection($@"Server=(localdb)\MSSQLLocalDB;Database={DatabaseName};Integrated Security=True;TrustServerCertificate=True;");
+    public OdbcConnection CreateOdbcConnection() => new OdbcConnection($@"Driver={{ODBC Driver 18 for SQL Server}};Server=(localdb)\MSSQLLocalDB;Database={DatabaseName};Trusted_Connection=Yes;TrustServerCertificate=Yes;");
+
+
+    private async Task CreateDatabaseAsync()
+    {
+        await using var connection = new SqlConnection(ConnectionStringMaster);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"create database [{DatabaseName}]";
+        await command.ExecuteNonQueryAsync();
+    }
+
+
+    private async Task CreateSchemaAsync()
+    {
+        var sql = await File.ReadAllTextAsync(@"SqlServer\Schema.sql");
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+
+    public async Task ResetSeedDataAsync()
+    {
+        var sql = await File.ReadAllTextAsync(@"SqlServer\ResetSeedData.sql");
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+
+    public async Task DisposeAsync()
+    {
+        await using var connection = new SqlConnection(ConnectionStringMaster);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            alter database [{DatabaseName}] set single_user with rollback immediate;
+            drop database [{DatabaseName}];
+            """;
+
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Paillave.Etl.SqlServer.Tests/Paillave.Etl.SqlServer.Tests.csproj
+++ b/src/Paillave.Etl.SqlServer.Tests/Paillave.Etl.SqlServer.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="ResetSeedData.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Schema.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paillave.Etl\Paillave.Etl.csproj" />
+    <ProjectReference Include="..\Paillave.Etl.SqlServer\Paillave.Etl.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paillave.Etl.SqlServer.Tests/ResetSeedData.sql
+++ b/src/Paillave.Etl.SqlServer.Tests/ResetSeedData.sql
@@ -1,0 +1,12 @@
+﻿
+alter table People set (system_versioning = off);
+truncate table People;
+alter table People set (system_versioning = on (history_table = dbo.PeopleHistory));
+
+truncate table Groups;
+
+insert into People (Firstname, Lastname, LastnamePrefix, [Role])
+values ('Thomas', 'Bangalter', null, null),
+       ('Guy-Manuel', 'de Homem-Christo', null, null),
+       ('Nicolas', 'Godin', null, 'Sexy boy'),
+       ('Jean-Benoît', 'Dunckel', null, 'Sexy boy');

--- a/src/Paillave.Etl.SqlServer.Tests/Schema.sql
+++ b/src/Paillave.Etl.SqlServer.Tests/Schema.sql
@@ -1,0 +1,20 @@
+create table People (
+    Id int identity primary key,
+    Firstname nvarchar(100) not null,
+    Lastname nvarchar(100) not null,
+    LastnamePrefix nvarchar(10) null,
+    [Role] nvarchar(100) null,
+    InsertedAtUtc datetime2(7) not null default getutcdate(),    
+    ValidFromUtc datetime2(7) generated always as row start not null,
+    ValidToUtc datetime2(7) generated always as row end not null,
+    period for system_time (ValidFromUtc, ValidToUtc)
+)
+with (system_versioning = on (history_table = dbo.PeopleHistory));
+
+set identity_insert People on;
+
+
+create table Groups (
+    PersonId int not null,
+    [Group] nvarchar(10) not null
+);

--- a/src/Paillave.Etl.SqlServer.Tests/SqlServerSaveTests.cs
+++ b/src/Paillave.Etl.SqlServer.Tests/SqlServerSaveTests.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Paillave.Etl.Core;
+using Paillave.Etl.SqlServer;
+using Paillave.Etl.SqlServer.Tests;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Paillave.Etl.Tests.SqlServer;
+
+[Collection("MSSQLLocalDB")]
+public sealed class SqlServerSaveTests(DatabaseFixture databaseFixture)
+{
+    private readonly IEnumerable<Person> peopleSource = [
+        new(1, "Thomas", "Bangaltar", null, "Robot",         new Expectation(Id: 1, WasInserted: false, WasChanged: true)),
+        new(2, "Guy-Manuel", "Homem-Christo", "de", "Robot", new Expectation(Id: 2, WasInserted: false, WasChanged: true)),
+        new(3, "Nicolas", "Godin", null, "Sexy boy",         new Expectation(Id: 3, WasInserted: false, WasChanged: false)),
+        new(4, "Jean-Benoît", "Dunckel", null, "Sexy boy",   new Expectation(Id: 4, WasInserted: false, WasChanged: false)),
+        new(null, "Laurent", "Garnier", null, "Techno god",  new Expectation(Id: 5, WasInserted: true,  WasChanged: true)),
+    ];
+
+
+    [Fact]
+    public async Task Insert_ReservedColumnName() => await ProcessInsert(databaseFixture.CreateConnection, [ new(1, "Daft Punk"), new(2, "Daft Punk") ]);
+
+
+    [Fact]
+    public async Task Insert_ReservedColumnName_OdbC() => await ProcessInsert(databaseFixture.CreateOdbcConnection, [new(1, "Daft Punk"), new(2, "Daft Punk")]);
+    
+
+    [Fact]
+    public async Task Upsert_WithReadBack() => await ProcessUpsert(databaseFixture.CreateConnection);
+
+
+    [Fact]
+    public async Task Upsert_WithReadBack_Odbc() => await ProcessUpsert(databaseFixture.CreateOdbcConnection);
+
+    
+    private async Task ProcessInsert(Func<IDbConnection> connectionFactory, IEnumerable<GroupAssociation> sourceData)
+    {
+        await databaseFixture.ResetSeedDataAsync();
+
+        var executionOptions = new ExecutionOptions<IEnumerable<GroupAssociation>>
+        {
+            Services = new ServiceCollection().AddTransient(_ => connectionFactory()).BuildServiceProvider(),
+        };
+
+        var result = await StreamProcessRunner.CreateAndExecuteAsync(
+            sourceData,
+            contextStream => contextStream
+                .CrossApply("Create values from enumeration", context => context)
+                .SqlServerSave("Insert", m => m
+                    .ToTable("Groups")),
+            executionOptions);
+
+        Assert.False(result.Failed, $"Process failed: {result.ErrorTraceEvent?.NodeName} ({result.ErrorTraceEvent?.NodeTypeName}): {result.ErrorTraceEvent?.Content?.Message}");
+    }
+
+
+    private async Task ProcessUpsert(Func<IDbConnection> connectionFactory)
+    {
+        await databaseFixture.ResetSeedDataAsync();
+        var startTimeUtc = DateTime.UtcNow;
+
+        var executionOptions = new ExecutionOptions<IEnumerable<Person>>
+        {
+            Services = new ServiceCollection().AddTransient(_ => connectionFactory()).BuildServiceProvider(),
+        };
+
+        var result = await StreamProcessRunner.CreateAndExecuteAsync(
+            peopleSource,
+            contextStream => contextStream
+                .CrossApply("Create values from enumeration", context => context)
+                .SqlServerSave("Upsert via Id", m => m
+                    .ToTable("People")
+                    .DoNotSave(p => new { p.Id, p.InsertedAtUtc, p.ValidFromUtc, p.ValidToUtc, p.Expectation })
+                    .SeekOn(p => p.Id!)
+                    .ReadBackChanges()),
+            executionOptions);
+        
+        Assert.False(result.Failed, result.Failed ? $"Process failed: {result.ErrorTraceEvent.NodeName} ({result.ErrorTraceEvent.NodeTypeName}): {result.ErrorTraceEvent.Content.Message}" : null);
+
+        foreach (var p in peopleSource)
+        {
+            await AssertDatabaseRowAsExpected(p, startTimeUtc);
+            AssertItemPopulatedWithDatabaseOutput(p);
+        }
+    }
+    
+
+    private static void AssertItemPopulatedWithDatabaseOutput(Person person)
+    {
+        Assert.Equal(person.Expectation.Id, person.Id);
+        Assert.NotNull(person.InsertedAtUtc);
+        Assert.NotNull(person.ValidFromUtc);
+        Assert.NotNull(person.ValidToUtc);
+    }
+
+
+    private async Task AssertDatabaseRowAsExpected(Person person, DateTime startTimeUtc)
+    {
+        await using var connection = databaseFixture.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select * from People where Id = @Id;";
+        command.Parameters.AddWithValue("Id", person.Id);
+
+        using var reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync(), $"Expected row with Id {person.Id} was not found in the database.");
+        Assert.Equal(person.Firstname, reader.GetString(nameof(Person.Firstname)));
+        Assert.Equal(person.Lastname, reader.GetString(nameof(Person.Lastname)));
+        Assert.Equal(person.LastnamePrefix, reader.IsDBNull(nameof(Person.LastnamePrefix)) ? null : reader.GetString("LastnamePrefix"));
+        Assert.Equal(person.Role, reader.GetString(nameof(Person.Role)));
+
+        if (person.Expectation.WasInserted)
+            Assert.True(reader.GetDateTime("InsertedAtUtc") > startTimeUtc, $"Expected row with Id {person.Id} to have database-generated timestamp.");
+        else
+            Assert.True(reader.GetDateTime("InsertedAtUtc") < startTimeUtc, $"Existing row with Id {person.Id} has newer timestamp than expected???");
+
+        //https://github.com/paillave/Etl.Net/issues/575
+        //if (person.Expectation.WasChanged)
+        //    Assert.True(reader.GetDateTime("ValidFromUtc") > startTimeUtc, $"Row with Id {person.Id} was expected to change, but didn’t trigger system-versioning.");
+        //else
+        //    Assert.True(reader.GetDateTime("ValidFromUtc") < startTimeUtc, $"Row without changes (Id {person.Id}) received an UPDATE and triggered system-versioning.");
+    }
+}
+
+
+internal record Expectation(int Id, bool WasInserted, bool WasChanged);
+
+internal class Person(int? Id, string Firstname, string Lastname, string? LastnamePrefix, string? Role, Expectation Expectation)
+{
+    public int? Id { get; set; } = Id;
+    public string Firstname { get; set; } = Firstname;
+    public string Lastname { get; set; } = Lastname;
+    public string? LastnamePrefix { get; set; } = LastnamePrefix;
+    public string? Role { get; set; } = Role;
+    public DateTime? InsertedAtUtc { get; set; } = null;
+    public DateTime? ValidFromUtc { get; set; } = null;
+    public DateTime? ValidToUtc { get; set; } = null;
+    public Expectation Expectation { get; } = Expectation;
+}
+
+internal record GroupAssociation(int PersonId, string Group);

--- a/src/Paillave.Etl.SqlServer.Tests/SqlServerSaveTests.cs
+++ b/src/Paillave.Etl.SqlServer.Tests/SqlServerSaveTests.cs
@@ -5,6 +5,7 @@ using Paillave.Etl.SqlServer.Tests;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,14 +22,39 @@ public sealed class SqlServerSaveTests(DatabaseFixture databaseFixture)
         new(null, "Laurent", "Garnier", null, "Techno god",  new Expectation(Id: 5, WasInserted: true,  WasChanged: true)),
     ];
 
-
-    [Fact]
-    public async Task Insert_ReservedColumnName() => await ProcessInsert(databaseFixture.CreateConnection, [ new(1, "Daft Punk"), new(2, "Daft Punk") ]);
+    private readonly Groups[] groupsSource = [ new(1, "Daft Punk"), new(4, "Air")];
 
 
     [Fact]
-    public async Task Insert_ReservedColumnName_OdbC() => await ProcessInsert(databaseFixture.CreateOdbcConnection, [new(1, "Daft Punk"), new(2, "Daft Punk")]);
-    
+    public async Task Insert_ReservedColumnName() => await ProcessInsert(databaseFixture.CreateConnection, groupsSource);
+
+
+    [Fact]
+    public async Task Insert_ReservedColumnName_OdbC() => await ProcessInsert(databaseFixture.CreateOdbcConnection, groupsSource);
+
+
+    [Fact(DisplayName = "Table name is derived from item type if unspecified")]
+    public async Task Insert_TableNameFromType()
+    {
+        await databaseFixture.ResetSeedDataAsync();
+
+        var executionOptions = new ExecutionOptions<IEnumerable<Groups>>
+        {
+            Services = new ServiceCollection().AddTransient<IDbConnection>(_ => databaseFixture.CreateConnection()).BuildServiceProvider(),
+        };
+
+        var result = await StreamProcessRunner.CreateAndExecuteAsync(
+            groupsSource,
+            contextStream => contextStream
+                .CrossApply("Create values from enumeration", context => context)
+                .SqlServerSave("Insert into table matching items’ type name"),
+            executionOptions);
+
+        Assert.False(result.Failed, $"Process failed: {result.ErrorTraceEvent?.NodeName} ({result.ErrorTraceEvent?.NodeTypeName}): {result.ErrorTraceEvent?.Content?.Message}");
+
+        await AssertGroupsInDatabaseEqual(groupsSource);
+    }
+
 
     [Fact]
     public async Task Upsert_WithReadBack() => await ProcessUpsert(databaseFixture.CreateConnection);
@@ -38,11 +64,11 @@ public sealed class SqlServerSaveTests(DatabaseFixture databaseFixture)
     public async Task Upsert_WithReadBack_Odbc() => await ProcessUpsert(databaseFixture.CreateOdbcConnection);
 
     
-    private async Task ProcessInsert(Func<IDbConnection> connectionFactory, IEnumerable<GroupAssociation> sourceData)
+    private async Task ProcessInsert(Func<IDbConnection> connectionFactory, IEnumerable<Groups> sourceData)
     {
         await databaseFixture.ResetSeedDataAsync();
 
-        var executionOptions = new ExecutionOptions<IEnumerable<GroupAssociation>>
+        var executionOptions = new ExecutionOptions<IEnumerable<Groups>>
         {
             Services = new ServiceCollection().AddTransient(_ => connectionFactory()).BuildServiceProvider(),
         };
@@ -56,6 +82,8 @@ public sealed class SqlServerSaveTests(DatabaseFixture databaseFixture)
             executionOptions);
 
         Assert.False(result.Failed, $"Process failed: {result.ErrorTraceEvent?.NodeName} ({result.ErrorTraceEvent?.NodeTypeName}): {result.ErrorTraceEvent?.Content?.Message}");
+
+        await AssertGroupsInDatabaseEqual(sourceData);
     }
 
 
@@ -126,6 +154,22 @@ public sealed class SqlServerSaveTests(DatabaseFixture databaseFixture)
         //else
         //    Assert.True(reader.GetDateTime("ValidFromUtc") < startTimeUtc, $"Row without changes (Id {person.Id}) received an UPDATE and triggered system-versioning.");
     }
+
+
+    private async Task AssertGroupsInDatabaseEqual(IEnumerable<Groups> expectedData)
+    {
+        await using var connection = databaseFixture.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"select * from {nameof(Groups)} order by PersonId";
+        using var reader = await command.ExecuteReaderAsync();
+        var actualData = new List<Groups>();
+        while (await reader.ReadAsync())
+            actualData.Add(new(reader.GetInt32(nameof(Groups.PersonId)), reader.GetString(nameof(Groups.Group))));
+
+        Assert.True(Enumerable.SequenceEqual(expectedData.OrderBy(g => g.PersonId), actualData), "Groups in database do not match Groups sent.");
+    }
 }
 
 
@@ -144,4 +188,4 @@ internal class Person(int? Id, string Firstname, string Lastname, string? Lastna
     public Expectation Expectation { get; } = Expectation;
 }
 
-internal record GroupAssociation(int PersonId, string Group);
+internal record Groups(int PersonId, string Group);

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -14,60 +14,46 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Paillave.Etl.SqlServer;
 
 
-public class SqlServerSaveCommandArgsBuilder<TIn, TValue> where TIn : class
+public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetValue) where TIn : class
 {
-    internal Func<TIn, TValue> GetValue { get; }
-    internal string ConnectionName { get; private set; }
+    internal string? ConnectionName { get; private set; }
     internal string Table { get; private set; } = typeof(TValue).Name;
-    internal Expression<Func<TValue, object>> Pivot { get; private set; } = null;
-    internal Expression<Func<TValue, object>> Computed { get; private set; } = null;
-    internal SqlServerSaveCommandArgsBuilder(Func<TIn, TValue> getValue) => (GetValue) = (getValue);
+    internal Expression<Func<TValue, object>>? Pivot { get; private set; } = null;
+    internal Expression<Func<TValue, object>>? Computed { get; private set; } = null;
 
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ToTable(string table)
     {
-        this.Table = table;
+        Table = table;
         return this;
     }
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> SeekOn(Expression<Func<TValue, object>> pivot)
     {
-        this.Pivot = pivot;
+        Pivot = pivot;
         return this;
     }
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> DoNotSave(Expression<Func<TValue, object>> computed)
     {
-        this.Computed = computed;
+        Computed = computed;
         return this;
     }
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> WithConnection(string connectionName)
     {
-        this.ConnectionName = connectionName;
+        ConnectionName = connectionName;
         return this;
     }
 
     internal SqlServerSaveCommandArgs<TIn, TStream, TValue> GetArgs<TStream>(TStream sourceStream) where TStream : IStream<TIn>
-        => new()
-        {
-            Table = this.Table,
-            Computed = this.Computed,
-            ConnectionName = this.ConnectionName,
-            GetValue = this.GetValue,
-            Pivot = this.Pivot,
-            SourceStream = sourceStream
-        };
+        => new(sourceStream, GetValue, Table, Pivot, Computed, ConnectionName);
 }
 
 
-public class SqlServerSaveCommandArgs<TIn, TStream, TValue>
-    where TIn : class
-    where TStream : IStream<TIn>
-{
-    public string Table { get; set; }
-    public Expression<Func<TValue, object>> Pivot { get; set; }
-    public Expression<Func<TValue, object>> Computed { get; set; }
-    public string ConnectionName { get; set; }
-    public TStream SourceStream { get; set; }
-    public Func<TIn, TValue> GetValue { get; set; }
-}
+public record SqlServerSaveCommandArgs<TIn, TStream, TValue>(TStream SourceStream,
+                                                             Func<TIn, TValue> GetValue,
+                                                             string Table,
+                                                             Expression<Func<TValue, object>>? Pivot,
+                                                             Expression<Func<TValue, object>>? Computed,
+                                                             string? ConnectionName
+                                                             ) where TIn : class where TStream : IStream<TIn>;
 
 
 public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
@@ -105,24 +91,19 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     }
 
 
-    private void ProcessItem(TValue item, string connectionName)
+    private void ProcessItem(TValue item, string? connectionName)
     {
         using var sqlConnection = connectionName == null
                                 ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
                                 : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
         if (sqlConnection.State != ConnectionState.Open)
             sqlConnection.Open();
-        // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
-        // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
-        // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);
+
         _usePositionalParameters = sqlConnection is OdbcConnection or OleDbConnection;
         var sqlStatement = GetSqlStatement();
         var command = sqlConnection.CreateCommand();
         command.CommandText = sqlStatement;
         command.CommandType = CommandType.Text;
-        // var command = new SqlCommand(sqlStatement, sqlConnection);
-        // Regex getParamRegex = new Regex(@"@(?<param>\w*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        // var allMatches = getParamRegex.Matches(base.Args.SqlQuery).ToList().Select(match => match.Groups["param"].Value).Distinct().ToList();
 
         //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
         //Otherwise just use all relevant properties of the item.

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -133,7 +133,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
 
         using var reader = command.ExecuteReader();
         if (reader.Read())
-            UpdateRecord(reader, item);
+            UpdateItem(item, reader);
     }
 
 
@@ -147,18 +147,16 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
         return parameter;
     }
 
-    
-    private static void UpdateRecord(IDataReader record, TValue item)
+
+    private void UpdateItem(TValue item, IDataReader record)
     {
-        var values = new Dictionary<string, object?>();
         for (int i = 0; i < record.FieldCount; i++)
         {
-            var recordValue = record.GetValue(i);
-            values[record.GetName(i)] = recordValue == DBNull.Value
-                ? null
-                : Convert.ChangeType(recordValue, record.GetFieldType(i));
+            var val = record.GetValue(i);
+            val = val == DBNull.Value ? null : Convert.ChangeType(val, record.GetFieldType(i));
+            if (_inPropertyInfos.TryGetValue(record.GetName(i), out var prop) && prop.GetSetMethod() is not null)
+                prop.SetValue(item, val);
         }
-        var updates = _inPropertyInfos.Join(values, i => i.Key, i => i.Key, (l, r) => new { Target = l.Value, NewValue = r.Value }, StringComparer.InvariantCultureIgnoreCase).ToList();
     }
 
 

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -16,11 +16,11 @@ namespace Paillave.Etl.SqlServer;
 
 public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetValue) where TIn : class
 {
-    internal string? ConnectionName { get; private set; }
-    internal string Table { get; private set; } = typeof(TValue).Name;
-    internal Expression<Func<TValue, object>>? Pivot { get; private set; } = null;
-    internal Expression<Func<TValue, object>>? Computed { get; private set; } = null;
-    internal bool ReadBack { get; private set; } = false;
+    private string? ConnectionName;
+    private string Table = typeof(TValue).Name;
+    private Expression<Func<TValue, object>>? Pivot;
+    private Expression<Func<TValue, object>>? Computed;
+    private bool ReadBack = false;
 
     /// <summary>
     /// The name of the table to which items will be saved, including schema as necessary. If omitted, <see cref="TValue"/>’s type name will be used.
@@ -89,7 +89,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
 
     protected override TStream CreateOutputStream(SqlServerSaveCommandArgs<TIn, TStream, TValue> args)
     {
-        var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i), args.ConnectionName));
+        var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i)));
         return base.CreateMatchingStream(ret, args.SourceStream);
     }
 
@@ -104,8 +104,8 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     {
         if (_sqlStatement == null)
         {
-            _pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
-            _computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
+            _pivot = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
+            _computed = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
             _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot, Args.ReadBackChanges);
             if (_usePositionalParameters)
                 (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
@@ -114,11 +114,11 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     }
 
 
-    private void ProcessItem(TValue item, string? connectionName)
+    private void ProcessItem(TValue item)
     {
-        using var sqlConnection = connectionName == null
+        using var sqlConnection = Args.ConnectionName == null
                                 ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
-                                : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
+                                : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(Args.ConnectionName);
         if (sqlConnection.State != ConnectionState.Open)
             sqlConnection.Open();
 
@@ -154,7 +154,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     }
 
 
-    private void UpdateItem(TValue item, IDataReader record)
+    private static void UpdateItem(TValue item, IDataReader record)
     {
         for (int i = 0; i < record.FieldCount; i++)
         {
@@ -166,7 +166,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     }
 
 
-    private string CreateSqlQuery(string table, IEnumerable<PropertyInfo> upsertProperties, IEnumerable<PropertyInfo> matchProperties)
+    private static string CreateSqlQuery(string table, IEnumerable<PropertyInfo> upsertProperties, IEnumerable<PropertyInfo> matchProperties, bool readBackChanges)
     {
         var upsertProps = upsertProperties.ToList();
         var matchProps = matchProperties.ToList();

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -102,10 +102,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
     
     private IDbConnection _sqlConnection;
     private string _sqlStatement;
-    private List<PropertyInfo> _pivot;
-    private List<PropertyInfo> _computed;
-    private bool _usePositionalParameters;
-    private List<string> _positionalParamsMap = [];
+    private List<string>? _paramPropertyNames;
 
 
     public SqlServerSaveStreamNode(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : base(name, args)
@@ -115,12 +112,18 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
                        : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(args.ConnectionName);
         this.ExecutionContext.AddDisposable(_sqlConnection);
 
-        _usePositionalParameters = _sqlConnection is OdbcConnection or OleDbConnection;
-        _pivot = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
-        _computed = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
-        _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot, Args.ReadBackChanges);
-        if (_usePositionalParameters)
-            (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
+        var usePositionalParameters = _sqlConnection is OdbcConnection or OleDbConnection;
+        var pivotProperties = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
+        var computedProperties = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
+        var upsertProperties = _inPropertyInfos.Values.Except(computedProperties).ToList();
+        _sqlStatement = CreateSqlQuery(Args.Table, upsertProperties, pivotProperties, Args.ReadBackChanges);
+
+        //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
+        //Otherwise just use all relevant properties of the item.
+        if (usePositionalParameters)
+            (_sqlStatement, _paramPropertyNames) = AdjustQueryForPositionalParameters(_sqlStatement);
+        else
+            _paramPropertyNames = upsertProperties.Union(pivotProperties).Select(i => i.Name).ToList();
     }
 
 
@@ -131,15 +134,8 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
 
         using var command = _sqlConnection.CreateCommand();
         command.CommandText = _sqlStatement;
-        command.CommandType = CommandType.Text;
 
-        //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
-        //Otherwise just use all relevant properties of the item.
-        var parameterNames = _usePositionalParameters
-                           ? _positionalParamsMap
-                           : _inPropertyInfos.Keys.Except(_computed.Select(i => i.Name));
-
-        foreach (var parameterName in parameterNames)
+        foreach (var parameterName in _paramPropertyNames!)
             command.Parameters.Add(MakeParameterFromPropertyname(command, item, parameterName));
 
         if (!Args.ReadBackChanges)

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -25,6 +25,10 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     /// <summary>
     /// The name of the table to which items will be saved, including schema as necessary. If omitted, <see cref="TValue"/>’s type name will be used.
     /// </summary>
+    /// <remarks>
+    /// This string is used verbatim in generated SQL and cannot be parameterized.
+    /// <strong>This is an SQL injection vector. Validate and escape untrusted input appropriately.</strong>
+    /// </remarks>
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ToTable(string table)
     {
         Table = table;
@@ -51,6 +55,9 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     /// </summary>
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ReadBackChanges()
     {
+        if (typeof(TValue).IsValueType)
+            throw new InvalidOperationException($"Type {typeof(TValue).Name} must be a reference type if {nameof(ReadBackChanges)}() is used.");
+
         ReadBack = true;
         return this;
     }
@@ -135,9 +142,16 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         foreach (var parameterName in parameterNames)
             command.Parameters.Add(MakeParameterFromPropertyname(command, item, parameterName));
 
-        using var reader = command.ExecuteReader();
-        if (Args.ReadBackChanges && reader.Read())
-            UpdateItem(item, reader);
+        if (!Args.ReadBackChanges)
+        {
+            command.ExecuteNonQuery();
+        }
+        else
+        {
+            using var reader = command.ExecuteReader();
+            if (reader.Read())
+                UpdateItem(item, reader);
+        }
     }
 
 
@@ -170,6 +184,9 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         var matchProps = matchProperties.ToList();
         var outputClause = readBackChanges ? "output inserted.*" : "";
 
+        if (upsertProps.Count == 0)
+            throw new InvalidOperationException($"No properties to save were found on type {typeof(TIn).Name} after excluding those in {nameof(SqlServerSaveCommandArgsBuilder<,>.DoNotSave)}().");
+
         var insert = $"""
             insert into {table} ({string.Join(", ", upsertProps.Select(o => $"[{o.Name}]"))})
             {outputClause}
@@ -179,10 +196,14 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         if (matchProps.Count == 0)
             return insert;
 
-        var pivotCondition = string.Join(" and ", matchProps.Select(p => $"[{p.Name}] = @{p.Name}"));
-        var setStatement = string.Join(", ", upsertProps.Except(matchProps).Select(i => $"[{i.Name}] = @{i.Name}"));
+        var updateProps = upsertProps.Except(matchProps).ToList();
+        if (updateProps.Count == 0)
+            throw new InvalidOperationException($"No properties to save were found on type {typeof(TIn).Name} after excluding those in {nameof(SqlServerSaveCommandArgsBuilder<,>.DoNotSave)}() and {nameof(SqlServerSaveCommandArgsBuilder<,>.SeekOn)}().");
+
+        var pivotCondition = string.Join(" and ", matchProps.Select(p => $"([{p.Name}] = @{p.Name} or ([{p.Name}] is null and @{p.Name} is null))"));
+        var setStatement = string.Join(", ", updateProps.Select(i => $"[{i.Name}] = @{i.Name}"));
         var query = $"""
-            update {table} with (updlock, serializable)
+            update top(1) {table} with (updlock, serializable)
             set {setStatement}
             {outputClause}
             where {pivotCondition}

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -23,6 +23,7 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue> where TIn : class
     internal Expression<Func<TValue, object>> Pivot { get; private set; } = null;
     internal Expression<Func<TValue, object>> Computed { get; private set; } = null;
     internal SqlServerSaveCommandArgsBuilder(Func<TIn, TValue> getValue) => (GetValue) = (getValue);
+
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ToTable(string table)
     {
         this.Table = table;
@@ -43,6 +44,7 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue> where TIn : class
         this.ConnectionName = connectionName;
         return this;
     }
+
     internal SqlServerSaveCommandArgs<TIn, TStream, TValue> GetArgs<TStream>(TStream sourceStream) where TStream : IStream<TIn>
         => new()
         {
@@ -67,6 +69,8 @@ public class SqlServerSaveCommandArgs<TIn, TStream, TValue>
     public TStream SourceStream { get; set; }
     public Func<TIn, TValue> GetValue { get; set; }
 }
+
+
 public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
     where TIn : class
     where TStream : IStream<TIn>
@@ -80,9 +84,12 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i), args.ConnectionName));
         return base.CreateMatchingStream(ret, args.SourceStream);
     }
-    private string _sqlStatement = null;
-    private List<PropertyInfo> _pivot = null;
-    private List<PropertyInfo> _computed = null;
+
+    private string _sqlStatement = null!;
+    private List<PropertyInfo> _pivot = null!;
+    private List<PropertyInfo> _computed = null!;
+
+
     private string GetSqlStatement()
     {
         if (_sqlStatement == null)
@@ -93,6 +100,8 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         }
         return _sqlStatement;
     }
+
+
     private void ProcessItem(TValue item, string connectionName)
     {
     var sqlConnection = connectionName == null 
@@ -129,6 +138,7 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
                 UpdateRecord(reader, item);
     }
 
+
     private static IDbCommand AdjustCommandForOdbcOrOleDb(IDbConnection connection, IDbCommand command)
     {
        var adjustedCommand = connection.CreateCommand();
@@ -152,9 +162,10 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
        return adjustedCommand;
     }
     
-    private void UpdateRecord(IDataReader record, TValue item)
+    
+    private static void UpdateRecord(IDataReader record, TValue item)
     {
-        IDictionary<string, object> values = new Dictionary<string, object>();
+        var values = new Dictionary<string, object?>();
         for (int i = 0; i < record.FieldCount; i++)
         {
             var recordValue = record.GetValue(i);
@@ -165,7 +176,8 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         var updates = _inPropertyInfos.Join(values, i => i.Key, i => i.Key, (l, r) => new { Target = l.Value, NewValue = r.Value }, StringComparer.InvariantCultureIgnoreCase).ToList();
     }
 
-    private string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed)
+
+    private static string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed)
     {
         var pivotsNames = pivot.Select(i => i.Name).ToList();
         var computedNames = computed.Select(i => i.Name).ToList();

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -122,7 +122,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         if (_sqlConnection.State != ConnectionState.Open)
             _sqlConnection.Open();
 
-        var command = _sqlConnection.CreateCommand();
+        using var command = _sqlConnection.CreateCommand();
         command.CommandText = _sqlStatement;
         command.CommandType = CommandType.Text;
 
@@ -179,23 +179,25 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         if (matchProps.Count == 0)
             return insert;
 
-        var pivotCondition = string.Join(" and ", matchProps.Select(p => $"p.[{p.Name}] = @{p.Name}"));
+        var pivotCondition = string.Join(" and ", matchProps.Select(p => $"[{p.Name}] = @{p.Name}"));
         var setStatement = string.Join(", ", upsertProps.Except(matchProps).Select(i => $"[{i.Name}] = @{i.Name}"));
         var query = $"""
-            if (exists(select 1 from {table} as p where {pivotCondition}))
-                update p
-                set {setStatement}
-                {outputClause}
-                from {table} as p where {pivotCondition}
-            else
+            update {table} with (updlock, serializable)
+            set {setStatement}
+            {outputClause}
+            where {pivotCondition}
+            
+            if (@@ROWCOUNT = 0)
+            begin
                 {insert}
+            end
             """;
 
         return query;
     }
 
 
-    [GeneratedRegex(@"@(\w+)")]
+    [GeneratedRegex(@"(?<!@)@(\w+)")]
     private static partial Regex ParameterRegex();
     /// <summary>
     /// Converts parameters to <c>?</c> and notes their order for later in <see cref="_positionalParamsMap"/>.

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -21,21 +21,34 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     internal Expression<Func<TValue, object>>? Pivot { get; private set; } = null;
     internal Expression<Func<TValue, object>>? Computed { get; private set; } = null;
 
+    /// <summary>
+    /// The name of the table to which items will be saved, including schema as necessary. If omitted, <see cref="TValue"/>’s type name will be used.
+    /// </summary>
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ToTable(string table)
     {
         Table = table;
         return this;
     }
+    /// <summary>
+    /// Properties specified here will be used to match existing database rows to update rather than insert (“upsert”).
+    /// </summary>
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> SeekOn(Expression<Func<TValue, object>> pivot)
     {
         Pivot = pivot;
         return this;
     }
-    public SqlServerSaveCommandArgsBuilder<TIn, TValue> DoNotSave(Expression<Func<TValue, object>> computed)
+    /// <summary>
+    /// Use this to exclude properties from the upsert. E.g. database-generated columns like ids and timestamps, or properties with no associated column.
+    /// </summary>
+    public SqlServerSaveCommandArgsBuilder<TIn, TValue> DoNotSave(Expression<Func<TValue, object>> propertiesToExclude)
     {
-        Computed = computed;
+        Computed = propertiesToExclude;
         return this;
     }
+    /// <summary>
+    /// Service key of the <see cref="IDbConnection"/> to use. <strong>This functionality is currently broken!</strong>
+    /// </summary>
+    [Obsolete("Keyed Services are not implemented yet. Using this will currently throw.", error: true)]
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> WithConnection(string connectionName)
     {
         ConnectionName = connectionName;

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -23,7 +23,8 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     private bool ReadBack = false;
 
     /// <summary>
-    /// The name of the table to which items will be saved, including schema as necessary. If omitted, <see cref="TValue"/>’s type name will be used.
+    /// The name of the table to which items will be saved, including schema as necessary.
+    /// If omitted, <typeparamref name="TValue"/>’s type name will be used.
     /// </summary>
     /// <remarks>
     /// This string is used verbatim in generated SQL and cannot be parameterized.
@@ -53,6 +54,7 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     /// <summary>
     /// Request rows back from the database and apply changes to the processed items.
     /// </summary>
+    /// <remarks>Only affects settable properties of <typeparamref name="TValue"/>.</remarks>
     public SqlServerSaveCommandArgsBuilder<TIn, TValue> ReadBackChanges()
     {
         if (typeof(TValue).IsValueType)

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -20,6 +20,7 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     internal string Table { get; private set; } = typeof(TValue).Name;
     internal Expression<Func<TValue, object>>? Pivot { get; private set; } = null;
     internal Expression<Func<TValue, object>>? Computed { get; private set; } = null;
+    internal bool ReadBack { get; private set; } = false;
 
     /// <summary>
     /// The name of the table to which items will be saved, including schema as necessary. If omitted, <see cref="TValue"/>’s type name will be used.
@@ -46,6 +47,14 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
         return this;
     }
     /// <summary>
+    /// Request rows back from the database and apply changes to the processed items.
+    /// </summary>
+    public SqlServerSaveCommandArgsBuilder<TIn, TValue> ReadBackChanges()
+    {
+        ReadBack = true;
+        return this;
+    }
+    /// <summary>
     /// Service key of the <see cref="IDbConnection"/> to use. <strong>This functionality is currently broken!</strong>
     /// </summary>
     [Obsolete("Keyed Services are not implemented yet. Using this will currently throw.", error: true)]
@@ -56,7 +65,7 @@ public class SqlServerSaveCommandArgsBuilder<TIn, TValue>(Func<TIn, TValue> GetV
     }
 
     internal SqlServerSaveCommandArgs<TIn, TStream, TValue> GetArgs<TStream>(TStream sourceStream) where TStream : IStream<TIn>
-        => new(sourceStream, GetValue, Table, Pivot, Computed, ConnectionName);
+        => new(sourceStream, GetValue, Table, Pivot, Computed, ConnectionName, ReadBack);
 }
 
 
@@ -65,7 +74,8 @@ public record SqlServerSaveCommandArgs<TIn, TStream, TValue>(TStream SourceStrea
                                                              string Table,
                                                              Expression<Func<TValue, object>>? Pivot,
                                                              Expression<Func<TValue, object>>? Computed,
-                                                             string? ConnectionName
+                                                             string? ConnectionName,
+                                                             bool ReadBackChanges
                                                              ) where TIn : class where TStream : IStream<TIn>;
 
 
@@ -96,7 +106,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
         {
             _pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
             _computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
-            _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot);
+            _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot, Args.ReadBackChanges);
             if (_usePositionalParameters)
                 (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
         }
@@ -128,7 +138,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
             command.Parameters.Add(MakeParameterFromPropertyname(command, item, parameterName));
 
         using var reader = command.ExecuteReader();
-        if (reader.Read())
+        if (Args.ReadBackChanges && reader.Read())
             UpdateItem(item, reader);
     }
 
@@ -160,10 +170,11 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     {
         var upsertProps = upsertProperties.ToList();
         var matchProps = matchProperties.ToList();
+        var outputClause = readBackChanges ? "output inserted.*" : "";
 
         var insert = $"""
             insert into {table} ({string.Join(", ", upsertProps.Select(o => $"[{o.Name}]"))})
-            output inserted.*
+            {outputClause}
             values ({string.Join(", ", upsertProps.Select(i => $"@{i.Name}"))})
             """;
 
@@ -176,7 +187,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
             if (exists(select 1 from {table} as p where {pivotCondition}))
                 update p
                 set {setStatement}
-                output inserted.*
+                {outputClause}
                 from {table} as p where {pivotCondition}
             else
                 {insert}

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -71,7 +71,7 @@ public class SqlServerSaveCommandArgs<TIn, TStream, TValue>
 }
 
 
-public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
+public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
     where TIn : class
     where TStream : IStream<TIn>
 {
@@ -88,15 +88,16 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
     private string _sqlStatement = null!;
     private List<PropertyInfo> _pivot = null!;
     private List<PropertyInfo> _computed = null!;
+    private List<string> _positionalParamsMap = [];
 
 
-    private string GetSqlStatement()
+    private string GetSqlStatement(bool usePositionalParameters)
     {
         if (_sqlStatement == null)
         {
             _pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
             _computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
-            _sqlStatement = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), _pivot, _computed);
+            _sqlStatement = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), _pivot, _computed, usePositionalParameters);
         }
         return _sqlStatement;
     }
@@ -112,56 +113,38 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
         // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
         // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);
-        var sqlStatement = GetSqlStatement();
+        var usePositionalParameters = sqlConnection is OdbcConnection or OleDbConnection;
+        var sqlStatement = GetSqlStatement(usePositionalParameters);
         var command = sqlConnection.CreateCommand();
         command.CommandText = sqlStatement;
         command.CommandType = CommandType.Text;
         // var command = new SqlCommand(sqlStatement, sqlConnection);
         // Regex getParamRegex = new Regex(@"@(?<param>\w*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         // var allMatches = getParamRegex.Matches(base.Args.SqlQuery).ToList().Select(match => match.Groups["param"].Value).Distinct().ToList();
-        foreach (var parameterName in _inPropertyInfos.Keys.Except(_computed.Select(i => i.Name)))
-        {
-            var parameter = command.CreateParameter();
-            parameter.ParameterName = $"@{parameterName}";
-            parameter.Value = _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value;
-            if (_inPropertyInfos[parameterName].PropertyType == typeof(byte[]))
-                parameter.DbType = DbType.Binary;
-            command.Parameters.Add(parameter);
-            // command.Parameters.Add(new SqlParameter($"@{parameterName}", _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value));
-        }
-        
-        if (sqlConnection is OdbcConnection or OleDbConnection)
-        {
-            command = AdjustCommandForOdbcOrOleDb(sqlConnection, command);
-        }
-        
-        using (var reader = command.ExecuteReader())
-            if (reader.Read())
-                UpdateRecord(reader, item);
+
+        //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
+        //Otherwise just use all relevant properties of the item.
+        var parameterNames = usePositionalParameters
+                           ? _positionalParamsMap
+                           : _inPropertyInfos.Keys.Except(_computed.Select(i => i.Name));
+
+        foreach (var parameterName in parameterNames)
+            command.Parameters.Add(MakeParameterFromPropertyname(command, item, parameterName));
+
+        using var reader = command.ExecuteReader();
+        if (reader.Read())
+            UpdateRecord(reader, item);
     }
 
 
-    private static IDbCommand AdjustCommandForOdbcOrOleDb(IDbConnection connection, IDbCommand command)
+    private static IDbDataParameter MakeParameterFromPropertyname(IDbCommand command, TValue item, string parameterName)
     {
-       var adjustedCommand = connection.CreateCommand();
-       adjustedCommand.CommandType = CommandType.Text;
-       
-       var regex = new Regex(@"@\w+");
-       adjustedCommand.CommandText = regex.Replace(command.CommandText, "?");
-
-       var parameterUsages = regex
-           .Matches(command.CommandText)
-           .Select(match => match.Value);
-
-       foreach (var parameterName in parameterUsages)
-       {
-           var parameter = adjustedCommand.CreateParameter();
-           parameter.ParameterName = parameterName;
-           parameter.Value = ((IDataParameter)command.Parameters[parameterName]).Value;
-           adjustedCommand.Parameters.Add(parameter);
-       }
-
-       return adjustedCommand;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = $"@{parameterName}";
+        parameter.Value = _inPropertyInfos[parameterName].GetValue(item) ?? DBNull.Value;
+        if (_inPropertyInfos[parameterName].PropertyType == typeof(byte[]))
+            parameter.DbType = DbType.Binary;
+        return parameter;
     }
 
     
@@ -179,7 +162,10 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
     }
 
 
-    private static string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed)
+    [GeneratedRegex(@"@(\w+)")]
+    private static partial Regex ParameterRegex();
+
+    private string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed, bool usePositionalParameters)
     {
         var pivotsNames = pivot.Select(i => i.Name).ToList();
         var computedNames = computed.Select(i => i.Name).ToList();
@@ -187,7 +173,7 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         StringBuilder sb = new();
         if (pivot.Count > 0)
         {
-            var pivotCondition = string.Join(" AND ", pivot.Select(p => $"p.[{p.Name}] = @{p.Name}"));
+            var pivotCondition = string.Join(" and ", pivot.Select(p => $"p.[{p.Name}] = @{p.Name}"));
             sb.AppendLine($"if(exists(select 1 from {table} as p where {pivotCondition} ))");
             var setStatement = string.Join(", ", allPropertyNames.Except(pivotsNames).Except(computedNames).Select(i => $"[{i}] = @{i}").ToList());
             sb.AppendLine($"update p set {setStatement} output inserted.* from {table} as p where {pivotCondition};");
@@ -196,6 +182,15 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
         var propsToInsert = allPropertyNames.Except(computedNames).ToList();
         sb.AppendLine($"insert into {table} ({string.Join(", ", propsToInsert.Select(o => $"[{o}]"))}) output inserted.*");
         sb.AppendLine($"values ({string.Join(", ", propsToInsert.Select(i => $"@{i}"))});");
-        return sb.ToString();
+
+        if (!usePositionalParameters)
+            return sb.ToString();
+
+        //Convert parameters to ? and note their order for later
+        return ParameterRegex().Replace(sb.ToString(), m =>
+        {
+            _positionalParamsMap.Add(m.Groups[1].Value);
+            return "?";
+        });
     }
 }

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -79,7 +79,7 @@ public record SqlServerSaveCommandArgs<TIn, TStream, TValue>(TStream SourceStrea
                                                              ) where TIn : class where TStream : IStream<TIn>;
 
 
-public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
+public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>
     where TIn : class
     where TStream : IStream<TIn>
 {
@@ -92,40 +92,38 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
         var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i)));
         return base.CreateMatchingStream(ret, args.SourceStream);
     }
-
-    private string _sqlStatement = null!;
-    private List<PropertyInfo> _pivot = null!;
-    private List<PropertyInfo> _computed = null!;
-    private bool _usePositionalParameters = false;
+    
+    private IDbConnection _sqlConnection;
+    private string _sqlStatement;
+    private List<PropertyInfo> _pivot;
+    private List<PropertyInfo> _computed;
+    private bool _usePositionalParameters;
     private List<string> _positionalParamsMap = [];
 
 
-    private string GetSqlStatement()
+    public SqlServerSaveStreamNode(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : base(name, args)
     {
-        if (_sqlStatement == null)
-        {
-            _pivot = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
-            _computed = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
-            _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot, Args.ReadBackChanges);
-            if (_usePositionalParameters)
-                (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
-        }
-        return _sqlStatement;
+        _sqlConnection = args.ConnectionName == null
+                       ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>()
+                       : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(args.ConnectionName);
+        this.ExecutionContext.AddDisposable(_sqlConnection);
+
+        _usePositionalParameters = _sqlConnection is OdbcConnection or OleDbConnection;
+        _pivot = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
+        _computed = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
+        _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot, Args.ReadBackChanges);
+        if (_usePositionalParameters)
+            (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
     }
 
 
     private void ProcessItem(TValue item)
     {
-        using var sqlConnection = Args.ConnectionName == null
-                                ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
-                                : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(Args.ConnectionName);
-        if (sqlConnection.State != ConnectionState.Open)
-            sqlConnection.Open();
+        if (_sqlConnection.State != ConnectionState.Open)
+            _sqlConnection.Open();
 
-        _usePositionalParameters = sqlConnection is OdbcConnection or OleDbConnection;
-        var sqlStatement = GetSqlStatement();
-        var command = sqlConnection.CreateCommand();
-        command.CommandText = sqlStatement;
+        var command = _sqlConnection.CreateCommand();
+        command.CommandText = _sqlStatement;
         command.CommandType = CommandType.Text;
 
         //Positional parameters must adhere to their position in the SQL statement, including repeat uses.

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -86,7 +86,7 @@ public record SqlServerSaveCommandArgs<TIn, TStream, TValue>(TStream SourceStrea
                                                              ) where TIn : class where TStream : IStream<TIn>;
 
 
-public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>
+public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : StreamNodeBase<TIn, TStream, SqlServerSaveCommandArgs<TIn, TStream, TValue>>(name, args)
     where TIn : class
     where TStream : IStream<TIn>
 {
@@ -99,37 +99,19 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         var ret = args.SourceStream.Observable.Do(i => ProcessItem(args.GetValue(i)));
         return base.CreateMatchingStream(ret, args.SourceStream);
     }
-    
-    private IDbConnection _sqlConnection;
-    private string _sqlStatement;
+
+    private bool _isInitialized = false;
+    private IDbConnection? _sqlConnection;
+    private string? _sqlStatement;
     private List<string>? _paramPropertyNames;
-
-
-    public SqlServerSaveStreamNode(string name, SqlServerSaveCommandArgs<TIn, TStream, TValue> args) : base(name, args)
-    {
-        _sqlConnection = args.ConnectionName == null
-                       ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>()
-                       : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(args.ConnectionName);
-        this.ExecutionContext.AddDisposable(_sqlConnection);
-
-        var usePositionalParameters = _sqlConnection is OdbcConnection or OleDbConnection;
-        var pivotProperties = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
-        var computedProperties = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
-        var upsertProperties = _inPropertyInfos.Values.Except(computedProperties).ToList();
-        _sqlStatement = CreateSqlQuery(Args.Table, upsertProperties, pivotProperties, Args.ReadBackChanges);
-
-        //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
-        //Otherwise just use all relevant properties of the item.
-        if (usePositionalParameters)
-            (_sqlStatement, _paramPropertyNames) = AdjustQueryForPositionalParameters(_sqlStatement);
-        else
-            _paramPropertyNames = upsertProperties.Union(pivotProperties).Select(i => i.Name).ToList();
-    }
-
+    
 
     private void ProcessItem(TValue item)
     {
-        if (_sqlConnection.State != ConnectionState.Open)
+        if (!_isInitialized)
+            Initialize();
+
+        if (_sqlConnection!.State != ConnectionState.Open)
             _sqlConnection.Open();
 
         using var command = _sqlConnection.CreateCommand();
@@ -148,6 +130,30 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
             if (reader.Read() || (reader.NextResult() && reader.Read()))
                 UpdateItem(item, reader);
         }
+    }
+
+    
+    private void Initialize()
+    {
+        _sqlConnection = args.ConnectionName == null
+                       ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>()
+                       : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(args.ConnectionName);
+        this.ExecutionContext.AddDisposable(_sqlConnection);
+
+        var usePositionalParameters = _sqlConnection is OdbcConnection or OleDbConnection;
+        var pivotParameters = Args.Pivot == null ? [] : Args.Pivot.GetPropertyInfos();
+        var computedProperties = Args.Computed == null ? [] : Args.Computed.GetPropertyInfos();
+        var upsertProperties = _inPropertyInfos.Values.Except(computedProperties).ToList();
+        _sqlStatement = CreateSqlQuery(Args.Table, upsertProperties, pivotParameters, Args.ReadBackChanges);
+
+        //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
+        //Otherwise just use all relevant properties of the item.
+        if (usePositionalParameters)
+            (_sqlStatement, _paramPropertyNames) = AdjustQueryForPositionalParameters(_sqlStatement);
+        else
+            _paramPropertyNames = upsertProperties.Union(pivotParameters).Select(i => i.Name).ToList();
+
+        _isInitialized = true;
     }
 
 

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -1,7 +1,6 @@
 using Paillave.Etl.Core;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Paillave.Etl.Reactive.Operators;
 using System.Linq;
 using System.Reflection;
@@ -88,16 +87,19 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     private string _sqlStatement = null!;
     private List<PropertyInfo> _pivot = null!;
     private List<PropertyInfo> _computed = null!;
+    private bool _usePositionalParameters = false;
     private List<string> _positionalParamsMap = [];
 
 
-    private string GetSqlStatement(bool usePositionalParameters)
+    private string GetSqlStatement()
     {
         if (_sqlStatement == null)
         {
             _pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
             _computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
-            _sqlStatement = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), _pivot, _computed, usePositionalParameters);
+            _sqlStatement = CreateSqlQuery(Args.Table, _inPropertyInfos.Values.Except(_computed), _pivot);
+            if (_usePositionalParameters)
+                (_sqlStatement, _positionalParamsMap) = AdjustQueryForPositionalParameters(_sqlStatement);
         }
         return _sqlStatement;
     }
@@ -113,8 +115,8 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
         // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
         // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
         // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);
-        var usePositionalParameters = sqlConnection is OdbcConnection or OleDbConnection;
-        var sqlStatement = GetSqlStatement(usePositionalParameters);
+        _usePositionalParameters = sqlConnection is OdbcConnection or OleDbConnection;
+        var sqlStatement = GetSqlStatement();
         var command = sqlConnection.CreateCommand();
         command.CommandText = sqlStatement;
         command.CommandType = CommandType.Text;
@@ -124,7 +126,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
 
         //Positional parameters must adhere to their position in the SQL statement, including repeat uses.
         //Otherwise just use all relevant properties of the item.
-        var parameterNames = usePositionalParameters
+        var parameterNames = _usePositionalParameters
                            ? _positionalParamsMap
                            : _inPropertyInfos.Keys.Except(_computed.Select(i => i.Name));
 
@@ -160,35 +162,49 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, 
     }
 
 
+    private string CreateSqlQuery(string table, IEnumerable<PropertyInfo> upsertProperties, IEnumerable<PropertyInfo> matchProperties)
+    {
+        var upsertProps = upsertProperties.ToList();
+        var matchProps = matchProperties.ToList();
+
+        var insert = $"""
+            insert into {table} ({string.Join(", ", upsertProps.Select(o => $"[{o.Name}]"))})
+            output inserted.*
+            values ({string.Join(", ", upsertProps.Select(i => $"@{i.Name}"))})
+            """;
+
+        if (matchProps.Count == 0)
+            return insert;
+
+        var pivotCondition = string.Join(" and ", matchProps.Select(p => $"p.[{p.Name}] = @{p.Name}"));
+        var setStatement = string.Join(", ", upsertProps.Except(matchProps).Select(i => $"[{i.Name}] = @{i.Name}"));
+        var query = $"""
+            if (exists(select 1 from {table} as p where {pivotCondition}))
+                update p
+                set {setStatement}
+                output inserted.*
+                from {table} as p where {pivotCondition}
+            else
+                {insert}
+            """;
+
+        return query;
+    }
+
+
     [GeneratedRegex(@"@(\w+)")]
     private static partial Regex ParameterRegex();
-
-    private string CreateSqlQuery(string table, List<PropertyInfo> allProperties, List<PropertyInfo> pivot, List<PropertyInfo> computed, bool usePositionalParameters)
+    /// <summary>
+    /// Converts parameters to <c>?</c> and notes their order for later in <see cref="_positionalParamsMap"/>.
+    /// </summary>
+    private static (string Query, List<string> PositionalParameterOrder) AdjustQueryForPositionalParameters(string query)
     {
-        var pivotsNames = pivot.Select(i => i.Name).ToList();
-        var computedNames = computed.Select(i => i.Name).ToList();
-        var allPropertyNames = allProperties.Select(i => i.Name).ToList();
-        StringBuilder sb = new();
-        if (pivot.Count > 0)
+        var parameters = new List<string>();
+        var newQuery = ParameterRegex().Replace(query, m =>
         {
-            var pivotCondition = string.Join(" and ", pivot.Select(p => $"p.[{p.Name}] = @{p.Name}"));
-            sb.AppendLine($"if(exists(select 1 from {table} as p where {pivotCondition} ))");
-            var setStatement = string.Join(", ", allPropertyNames.Except(pivotsNames).Except(computedNames).Select(i => $"[{i}] = @{i}").ToList());
-            sb.AppendLine($"update p set {setStatement} output inserted.* from {table} as p where {pivotCondition};");
-            sb.AppendLine("else");
-        }
-        var propsToInsert = allPropertyNames.Except(computedNames).ToList();
-        sb.AppendLine($"insert into {table} ({string.Join(", ", propsToInsert.Select(o => $"[{o}]"))}) output inserted.*");
-        sb.AppendLine($"values ({string.Join(", ", propsToInsert.Select(i => $"@{i}"))});");
-
-        if (!usePositionalParameters)
-            return sb.ToString();
-
-        //Convert parameters to ? and note their order for later
-        return ParameterRegex().Replace(sb.ToString(), m =>
-        {
-            _positionalParamsMap.Add(m.Groups[1].Value);
+            parameters.Add(m.Groups[1].Value);
             return "?";
         });
+        return (newQuery, parameters);
     }
 }

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -149,7 +149,7 @@ public partial class SqlServerSaveStreamNode<TIn, TStream, TValue> : StreamNodeB
         else
         {
             using var reader = command.ExecuteReader();
-            if (reader.Read())
+            if (reader.Read() || (reader.NextResult() && reader.Read()))
                 UpdateItem(item, reader);
         }
     }

--- a/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
+++ b/src/Paillave.Etl.SqlServer/SqlServerSaveStreamNode.cs
@@ -104,9 +104,11 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
 
     private void ProcessItem(TValue item, string connectionName)
     {
-    var sqlConnection = connectionName == null 
-        ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
-        : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
+        using var sqlConnection = connectionName == null
+                                ? this.ExecutionContext.Services.GetRequiredService<IDbConnection>() 
+                                : this.ExecutionContext.Services.GetRequiredKeyedService<IDbConnection>(connectionName);
+        if (sqlConnection.State != ConnectionState.Open)
+            sqlConnection.Open();
         // List<PropertyInfo> pivot = base.Args.Pivot == null ? new List<PropertyInfo>() : base.Args.Pivot.GetPropertyInfos();
         // List<PropertyInfo> computed = base.Args.Computed == null ? new List<PropertyInfo>() : base.Args.Computed.GetPropertyInfos();
         // var sqlQuery = CreateSqlQuery(base.Args.Table, typeof(TIn).GetProperties().ToList(), pivot, computed);
@@ -161,7 +163,7 @@ public class SqlServerSaveStreamNode<TIn, TStream, TValue>(string name, SqlServe
 
        return adjustedCommand;
     }
-    
+
     
     private static void UpdateRecord(IDataReader record, TValue item)
     {

--- a/src/Paillave.Etl.Tests/Paillave.Etl.Tests.csproj
+++ b/src/Paillave.Etl.Tests/Paillave.Etl.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/Paillave.Etl.sln
+++ b/src/Paillave.Etl.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.FromConfigurat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.Tests", "Paillave.Etl.Tests\Paillave.Etl.Tests.csproj", "{03F552CF-D994-4580-9166-C53BF5692F9A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paillave.Etl.SqlServer.Tests", "Paillave.Etl.SqlServer.Tests\Paillave.Etl.SqlServer.Tests.csproj", "{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -447,6 +449,18 @@ Global
 		{03F552CF-D994-4580-9166-C53BF5692F9A}.Release|x64.Build.0 = Release|Any CPU
 		{03F552CF-D994-4580-9166-C53BF5692F9A}.Release|x86.ActiveCfg = Release|Any CPU
 		{03F552CF-D994-4580-9166-C53BF5692F9A}.Release|x86.Build.0 = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|x64.Build.0 = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A3D2F09-CC53-79B6-E510-1C77D66BBB13}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Right, sorry, forget the individual PRs. Here’s a single one with small commits that should be reasonably reviewable.

Bug fixes:
1. Connection pool no longer gets exhausted because connections were opened in a loop and never closed.
2. Reading database values back and applying them to the items now works.

Features:
1. Reading database rows back is now opt-in via `ReadBackChanges()`. I don’t imagine most people need it and not doing it improves perf and stability. Since the functionality didn’t previously work anyway, this opt-in shouldn’t break anyone’s existing code.

Performance:
1. Conversion of the SQL statement to positional parameters now happens only once per execution instead of twice per item.
2. The conversion regex is now compiled.
3. Removed several unnecessary collection iterations and allocations.
4. Database connection is only requested from the service provider and opened once per execution, rather then per item.

Docs:
1. Added XML docs to the ArgsBuilder methods.

Maintainability:
1. Fixed linter warnings.
2. Centralized initialization of private fields in constructor.
3. Modernized several things to new C# features such as collection initializers, `var`, primary constructors, multiline string interpolation.
4. Generally removed boilerplate, added whitespace.

I’m open to working on the documentation pages as well.

Cheers!